### PR TITLE
Faastlane support

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,7 @@
+{
+  "skills": {
+    "disabled": [
+      "frontend-design"
+    ]
+  }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: publish-ios
+on:
+  push:
+    branches: [ main ]
+  release:
+    types: [ created ]
+  workflow_dispatch:
+
+jobs:
+  testflight:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v22
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Build and upload to TestFlight
+        env:
+          TEAM_ID: ${{ secrets.TEAM_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+        run: nix develop --command fastlane beta

--- a/dependencies/wawona/android.nix
+++ b/dependencies/wawona/android.nix
@@ -12,6 +12,8 @@
   jdk17 ? pkgs.jdk17,
   gradle ? pkgs.gradle,
   targetPkgs,
+  gradleTask ? ":app:assembleDebug",
+  release ? false,
   ...
 }:
 
@@ -561,7 +563,7 @@ in
 
     mitmCache = gradleSupport.mitmCache;
     gradleFlags = gradleSupport.gradleFlags;
-    gradleUpdateTask = ":app:assembleDebug";
+    gradleUpdateTask = gradleTask;
     enableParallelUpdating = false;
 
     nativeBuildInputs = (with pkgs; [
@@ -678,7 +680,7 @@ in
       # Dexing Compose artifacts can exceed the default 512m Gradle JVM heap in
       # sandboxed builds. Pin explicit JVM args so D8/R8 has enough memory.
       export GRADLE_OPTS="-Xmx6144m -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"
-      gradle :app:assembleDebug --no-build-cache --no-watch-fs --no-daemon --max-workers=1 \
+      gradle ${gradleTask} --no-build-cache --no-watch-fs --no-daemon --max-workers=1 \
         -Dorg.gradle.parallel=false \
         -Dorg.gradle.workers.max=1 \
         -Dorg.gradle.daemon=false \

--- a/fastlane/.env.example
+++ b/fastlane/.env.example
@@ -1,0 +1,15 @@
+# App Store Connect API Key
+ASC_KEY_ID=
+ASC_ISSUER_ID=
+ASC_KEY_CONTENT=
+
+# Apple Developer Team ID
+TEAM_ID=
+
+# App Identifiers
+APP_IDENTIFIER=com.aspauldingcode.Wawona
+ANDROID_PACKAGE_NAME=com.aspauldingcode.wawona
+APPLE_ID=
+
+# Play Store Service Account
+JSON_KEY_FILE=

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+app_identifier("com.aspauldingcode.Wawona")
+apple_id("your-apple-id@domain.com")

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,2 +1,9 @@
-app_identifier("com.aspauldingcode.Wawona")
-apple_id("your-apple-id@domain.com")
+app_identifier(ENV["APP_IDENTIFIER"] || "com.aspauldingcode.Wawona")
+apple_id(ENV["APPLE_ID"] || "your-apple-id@domain.com")
+itc_team_id(ENV["ITC_TEAM_ID"])
+team_id(ENV["TEAM_ID"])
+
+for_platform :android do
+  package_name(ENV["ANDROID_PACKAGE_NAME"] || "com.aspauldingcode.wawona")
+  json_key_file(ENV["JSON_KEY_FILE"])
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,31 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Push a new beta build to TestFlight"
+  lane :beta do
+    # 1. Authenticate via API key (from ENV)
+    # The API key should be generated in App Store Connect
+    app_store_connect_api_key(
+      key_id:     ENV["ASC_KEY_ID"],
+      issuer_id:  ENV["ASC_ISSUER_ID"],
+      key_content: ENV["ASC_KEY_CONTENT"],
+      in_house:    false
+    )
+
+    # 2. Build the app using Wawona’s Nix targets
+    # This requires TEAM_ID to be set in the environment and --impure
+    UI.message("Building IPA via Nix...")
+    sh("nix build .#wawona-ios-ipa --impure")
+
+    # 3. Find the IPA in the Nix result directory
+    ipa = sh("find result -name '*.ipa' | head -n1").strip
+    UI.user_error!("IPA not found in result/") if ipa.empty?
+    UI.success("Built IPA at #{ipa}")
+
+    # 4. Upload to TestFlight
+    upload_to_testflight(
+      ipa: ipa,
+      skip_waiting_for_build_processing: true
+    )
+  end
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,31 +1,138 @@
+# Wawona Fastlane Configuration
+# Supports iOS (TestFlight/App Store) and Android (Play Store)
+# Versioning synced from project root VERSION file
+
 default_platform(:ios)
 
+# --- Common Helper Functions ---
+
+# Read version from root VERSION file
+def get_wawona_version
+  version = File.read("../VERSION").strip
+  UI.message("Wawona version: #{version}")
+  version
+end
+
+# Check if environment variables are set
+def check_env(vars)
+  missing = vars.select { |v| ENV[v].nil? || ENV[v].empty? }
+  unless missing.empty?
+    UI.user_error!("Missing environment variables: #{missing.join(', ')}. See fastlane/.env.example")
+  end
+end
+
+# --- Global Lanes ---
+
+desc "Sync version from VERSION file to all platform manifests"
+lane :sync_version do |options|
+  version = get_wawona_version
+  
+  # 1. Update Cargo.toml
+  UI.message("Updating Cargo.toml version...")
+  cargo_toml = File.read("../Cargo.toml")
+  new_cargo = cargo_toml.gsub(/^version = ".*"$/, "version = \"#{version}\"")
+  File.write("../Cargo.toml", new_cargo)
+
+  # 2. Update Android build.gradle.kts
+  UI.message("Updating Android versionName...")
+  gradle_path = "../android/app/build.gradle.kts"
+  if File.exist?(gradle_path)
+    gradle_content = File.read(gradle_path)
+    new_gradle = gradle_content.gsub(/versionName = ".*"$/, "versionName = \"#{version}\"")
+    File.write(gradle_path, new_gradle)
+  end
+
+  UI.success("Versions synced to #{version}")
+end
+
+desc "Verify release environment"
+lane :validate_env do
+  check_env(["TEAM_ID", "ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_KEY_CONTENT"])
+  UI.success("Environment validated")
+end
+
+# --- iOS Platform ---
+
 platform :ios do
-  desc "Push a new beta build to TestFlight"
-  lane :beta do
-    # 1. Authenticate via API key (from ENV)
-    # The API key should be generated in App Store Connect
+  before_all do
+    # Authenticate via API key (from ENV)
     app_store_connect_api_key(
       key_id:     ENV["ASC_KEY_ID"],
       issuer_id:  ENV["ASC_ISSUER_ID"],
       key_content: ENV["ASC_KEY_CONTENT"],
       in_house:    false
     )
+  end
 
-    # 2. Build the app using Wawona’s Nix targets
-    # This requires TEAM_ID to be set in the environment and --impure
-    UI.message("Building IPA via Nix...")
+  desc "Push a new beta build to TestFlight"
+  lane :beta do
+    validate_env
+    sync_version
+
+    # Build IPA via Nix (requires TEAM_ID and --impure)
+    UI.message("Building iOS IPA via Nix...")
     sh("nix build .#wawona-ios-ipa --impure")
 
-    # 3. Find the IPA in the Nix result directory
+    # Find IPA in result/
     ipa = sh("find result -name '*.ipa' | head -n1").strip
     UI.user_error!("IPA not found in result/") if ipa.empty?
     UI.success("Built IPA at #{ipa}")
 
-    # 4. Upload to TestFlight
     upload_to_testflight(
       ipa: ipa,
       skip_waiting_for_build_processing: true
+    )
+  end
+
+  desc "Submit for App Store Review"
+  lane :release do
+    validate_env
+    sync_version
+
+    UI.message("Building iOS IPA for App Store...")
+    sh("nix build .#wawona-ios-ipa --impure")
+    ipa = sh("find result -name '*.ipa' | head -n1").strip
+
+    deliver(
+      ipa: ipa,
+      submit_for_review: true,
+      force: true, # Skip HTML report
+      skip_screenshots: true,
+      skip_metadata: true # Metadata managed in App Store Connect
+    )
+  end
+end
+
+# --- Android Platform ---
+
+platform :android do
+  desc "Submit a new Internal track build to Google Play"
+  lane :beta do
+    sync_version
+    check_env(["JSON_KEY_FILE"])
+
+    UI.message("Building Android APK via Nix...")
+    # wawona-android-release uses :app:assembleRelease
+    sh("nix build .#wawona-android-release --impure")
+
+    apk = "result/bin/Wawona.apk"
+    UI.user_error!("APK not found at #{apk}") unless File.exist?("../#{apk}")
+
+    supply(
+      apk: apk,
+      track: "internal",
+      package_name: ENV["ANDROID_PACKAGE_NAME"] || "com.aspauldingcode.wawona",
+      json_key_file: ENV["JSON_KEY_FILE"]
+    )
+  end
+
+  desc "Promote Internal to Production"
+  lane :promote_to_production do
+    supply(
+      track: "internal",
+      track_promote_to: "production",
+      package_name: ENV["ANDROID_PACKAGE_NAME"] || "com.aspauldingcode.wawona",
+      json_key_file: ENV["JSON_KEY_FILE"]
     )
   end
 end

--- a/flake.nix
+++ b/flake.nix
@@ -506,7 +506,7 @@
         apple = import ./dependencies/apple { inherit (pkgs) lib pkgs; nixXcodeenvtests = inputs."nix-xcodeenvtests"; };
       in if pkgs.stdenv.isDarwin then (pkgs.mkShell {
         nativeBuildInputs = [ pkgs.pkg-config ];
-        buildInputs = [ pkgs.nix-output-monitor pkgs.rustToolchain pkgs.libxkbcommon pkgs.libffi pkgs.wayland-protocols pkgs.openssl ]
+        buildInputs = [ pkgs.nix-output-monitor pkgs.rustToolchain pkgs.libxkbcommon pkgs.libffi pkgs.wayland-protocols pkgs.openssl pkgs.fastlane ]
           ++ [ apple.ensureIosSimSDK apple.findXcodeScript ];
         shellHook = "export XDG_RUNTIME_DIR=\"/tmp/wawona-$(id -u)\"; export WAYLAND_DISPLAY=\"wayland-0\"; alias nb='nom build'; alias nd='nom develop';";
       }) else (pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -520,7 +520,7 @@
         apple = import ./dependencies/apple { inherit (pkgs) lib pkgs; nixXcodeenvtests = inputs."nix-xcodeenvtests"; };
       in if pkgs.stdenv.isDarwin then (pkgs.mkShell {
         nativeBuildInputs = [ pkgs.pkg-config ];
-        buildInputs = [ pkgs.nix-output-monitor pkgs.rustToolchain pkgs.libxkbcommon pkgs.libffi pkgs.wayland-protocols pkgs.openssl pkgs.fastlane ]
+        buildInputs = [ pkgs.nix-output-monitor pkgs.rustToolchain pkgs.libxkbcommon pkgs.libffi pkgs.wayland-protocols pkgs.openssl pkgs.fastlane pkgs.ruby ]
           ++ [ apple.ensureIosSimSDK apple.findXcodeScript ];
         shellHook = "export XDG_RUNTIME_DIR=\"/tmp/wawona-$(id -u)\"; export WAYLAND_DISPLAY=\"wayland-0\"; alias nb='nom build'; alias nd='nom develop';";
       }) else (pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -252,6 +252,19 @@
           waypipe = toolchainsAndroid.buildForAndroid "waypipe" { };
         };
 
+        wawonaAndroidReleasePkg = import ./dependencies/wawona/android.nix {
+          pkgs = androidPkgs;
+          buildModule = toolchainsAndroid;
+          inherit (androidPkgs) lib stdenv clang pkg-config unzip zip patchelf file util-linux glslang mesa;
+          inherit gradle jdk17 wawonaSrc androidSDK androidUtils;
+          androidToolchain = toolchainsAndroid.androidToolchain;
+          rustBackend = backend-android;
+          targetPkgs = pkgsAndroidCross;
+          waypipe = toolchainsAndroid.buildForAndroid "waypipe" { };
+          gradleTask = ":app:assembleRelease";
+          release = true;
+        };
+
         androidToolchainSanity = import ./dependencies/toolchains/android-toolchain-sanity.nix {
           pkgs = androidPkgs;
           androidToolchain = toolchainsAndroid.androidToolchain;
@@ -316,6 +329,7 @@
 
         packages = commonPackages // (pkgs.lib.optionalAttrs (isLinuxHost || androidSDK != null) {
           wawona-android = wawonaAndroidPkg;
+          wawona-android-release = wawonaAndroidReleasePkg;
           wawona-android-backend = backend-android;
           android-toolchain-sanity = androidToolchainSanity;
           gradlegen = gradlegenPkg.generateScript;


### PR DESCRIPTION
### Summary of changes:

1. **Enhanced `flake.nix` & `android.nix`**: Added `wawona-android-release` target and enabled `gradleTask` overrides. `fastlane` added to Darwin devShell.
2. **Unified `fastlane/Appfile`**: Added multi-platform support. Uses environment variables for `app_identifier`, `apple_id`, and Android `package_name`.
3. **Expanded `fastlane/Fastfile`**:
    * `sync_version`: Automatically propagates version from root `VERSION` file to `Cargo.toml` and `android/app/build.gradle.kts`.
    * **iOS Lanes**: `beta` (TestFlight) and `release` (App Store) using Nix-built IPAs.
    * **Android Lanes**: `beta` (Play Store Internal) using Nix-built release APKs and `promote_to_production`.
    * `validate_env`: Helper to ensure required credentials exist before building.
4. **Added `fastlane/.env.example`**: Template for required secrets (`ASC_KEY`, `TEAM_ID`, `JSON_KEY_FILE`).
5. **GitHub CI**: `publish.yml` workflow triggers Fastlane on macOS runners for automated delivery.

To use locally, copy `fastlane/.env.example` to `.env` and fill secrets. Then run:

```bash
# Sync versions across manifests
nix develop --command fastlane sync_version

# Deploy iOS to TestFlight
nix develop --command fastlane ios beta

# Deploy Android to Play Store
nix develop --command fastlane android beta
```

System uses Nix for hermetic binary generation and Fastlane for platform-specific API orchestration.