### PR TITLE
ci: add release workflow for macOS DMG and Android APK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  NIXPKGS_ALLOW_UNFREE: '1'
+
+jobs:
+  release-macos:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          XCODE_APP=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE_APP" ]; then
+            echo "::error::No Xcode installation found"
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE_APP"
+
+      - uses: DeterminateSystems/nix-installer-action@v16
+        with:
+          extra-conf: |
+            sandbox = relaxed
+            allow-import-from-derivation = true
+
+      - name: Build macOS app
+        run: ./.github/scripts/nix-retry.sh nix build .#wawona-macos --print-build-logs
+
+      - name: Create DMG
+        run: |
+          VERSION=$(cat VERSION)
+          mkdir -p dmg-staging
+          cp -R result/Applications/Wawona.app dmg-staging/
+          ln -s /Applications dmg-staging/Applications
+          hdiutil create -volname "Wawona" -srcfolder dmg-staging \
+            -ov -format UDZO "Wawona-${VERSION}.dmg"
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg
+          path: Wawona-*.dmg
+
+  release-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+          docker image prune -af || true
+
+      - uses: DeterminateSystems/nix-installer-action@v16
+        with:
+          extra-conf: |
+            build-dir = /nix/build
+            sandbox = relaxed
+            allow-import-from-derivation = true
+
+      - name: Build Android APK
+        run: ./.github/scripts/nix-retry.sh nix build .#wawona-android --print-build-logs
+
+      - name: Copy APK
+        run: |
+          VERSION=$(cat VERSION)
+          cp result/bin/Wawona.apk "Wawona-${VERSION}.apk"
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: Wawona-*.apk
+
+  create-release:
+    needs: [release-macos, release-android]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+
+          PRERELEASE=""
+          if echo "$VERSION" | grep -q '-'; then
+            PRERELEASE="--prerelease"
+          fi
+
+          gh release create "$TAG" \
+            --title "Wawona v${VERSION}" \
+            --generate-notes \
+            $PRERELEASE \
+            artifacts/*

--- a/android/app/src/main/java/com/aspauldingcode/wawona/MachineHomeScreen.kt
+++ b/android/app/src/main/java/com/aspauldingcode/wawona/MachineHomeScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.ElevatedAssistChip
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -196,6 +197,7 @@ fun MachineWelcomeScreen(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun MachineGridCard(
     profile: MachineProfile,
@@ -341,7 +343,7 @@ fun MachineSessionStrip(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 private fun MachineEditorSheet(
     title: String,

--- a/dependencies/clients/weston/macos.nix
+++ b/dependencies/clients/weston/macos.nix
@@ -11,28 +11,28 @@ stdenv.mkDerivation rec {
   
   # Fetch linux input headers for macOS shim
   linux_input_h = fetchurl {
-    url = "https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/input.h";
-    sha256 = "sha256-ciO4IN6ANMgnw/yBe2dApcUcqDMkgLhtagwUJzD7I54="; 
+    url = "https://raw.githubusercontent.com/torvalds/linux/v6.6/include/uapi/linux/input.h";
+    sha256 = "06rha7nmqpadi6q6xz64rs86xc5lgdkq1bdcbr9rw2lp33ziypqa";
   };
   linux_input_event_codes_h = fetchurl {
-    url = "https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/input-event-codes.h";
-    sha256 = "sha256-ORbz0jviAG+Hqy5+4vVqyGSWax9lDHaJwMpDUTSGHsk=";
+    url = "https://raw.githubusercontent.com/torvalds/linux/v6.6/include/uapi/linux/input-event-codes.h";
+    sha256 = "14sl96hc8j48ikjgg4jynm4gsvax5ywdypyahzi2816l4xlvxd93";
   };
   libdrm_fourcc_h = fetchurl {
-    url = "https://gitlab.freedesktop.org/mesa/drm/-/raw/main/include/drm/drm_fourcc.h";
-    sha256 = "sha256-qFbvL2tD6PeyaHFZThkYZMVAoDcg1xwT7opFDSarxi0=";
+    url = "https://gitlab.freedesktop.org/mesa/drm/-/raw/libdrm-2.4.124/include/drm/drm_fourcc.h";
+    sha256 = "1yv2y0mcb16jifn3shkcl7lgkx4vsq7glrvwa6m1z7c03kl47sxr";
   };
   libdrm_h = fetchurl {
-    url = "https://gitlab.freedesktop.org/mesa/drm/-/raw/main/include/drm/drm.h";
-    sha256 = "sha256-+erb+g+eGurMJ/XJMco717RpdNutgXzQL+YBzLXN8I0=";
+    url = "https://gitlab.freedesktop.org/mesa/drm/-/raw/libdrm-2.4.124/include/drm/drm.h";
+    sha256 = "1s6swhbxr1y4k9ld906hnknr40km5k7a6i2idq92xb72avqaz03b";
   };
   libdrm_mode_h = fetchurl {
-    url = "https://gitlab.freedesktop.org/mesa/drm/-/raw/main/include/drm/drm_mode.h";
-    sha256 = "sha256-7kBowCbftshcZoy05B/5y/MOmcEMXn7yrRx4cNP5o78=";
+    url = "https://gitlab.freedesktop.org/mesa/drm/-/raw/libdrm-2.4.124/include/drm/drm_mode.h";
+    sha256 = "1nk8sy1frp0wy73dd84lxrqxbbqhnj47ngi5xfh9c83rv8088i4z";
   };
   libdrm_xf86drm_h = fetchurl {
-    url = "https://gitlab.freedesktop.org/mesa/drm/-/raw/main/xf86drm.h";
-    sha256 = "sha256-X62GrL3cw7amhWkNoMfeWUEtNU0TdWRHNGcvXGvfQgI=";
+    url = "https://gitlab.freedesktop.org/mesa/drm/-/raw/libdrm-2.4.124/xf86drm.h";
+    sha256 = "0imd0r19rl8wajzaa9f0rf4j4z4jrmm6cnsia4whpbl5hrx9v36a";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config wayland-scanner python3 ];

--- a/dependencies/wawona/common.nix
+++ b/dependencies/wawona/common.nix
@@ -102,7 +102,7 @@ rec {
   ];
 
   # Apple-only deployment target flag (not valid for Android)
-  appleCFlags = [ "-mmacosx-version-min=26.0" ];
+  appleCFlags = [ "-mmacosx-version-min=14.0" ];
 
   commonObjCFlags = [
     "-Wall"

--- a/dependencies/wawona/macos.nix
+++ b/dependencies/wawona/macos.nix
@@ -30,8 +30,8 @@ let
           export XCODE_APP
           export DEVELOPER_DIR="$XCODE_APP/Contents/Developer"
           export PATH="$DEVELOPER_DIR/usr/bin:$PATH"
-          # Tahoe (26.0) SDK discovery
-          export SDKROOT="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk"
+          # SDK discovery
+          export SDKROOT="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
           if [ ! -d "$SDKROOT" ]; then
              SDKROOT=$(xcrun --sdk macosx --show-sdk-path 2>/dev/null || true)
           fi
@@ -137,7 +137,7 @@ let
         mkdir -p "''$OUT_CAR"
         if "''$ACTOOL" "''$ICON_TMP/Wawona.icon" --compile "''$OUT_CAR" \
             --platform macosx --target-device mac \
-            --minimum-deployment-target 26.0 \
+            --minimum-deployment-target 14.0 \
             --app-icon Wawona --include-all-app-icons \
             --output-format human-readable-text --notices --warnings \
             --development-region en --enable-on-demand-resources NO \
@@ -691,7 +691,7 @@ MVK_ICD_EOF
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2025-${currentYear} Alex Spaulding. All rights reserved.</string>
     <key>LSMinimumSystemVersion</key>
-    <string>26.0</string>
+    <string>14.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>CFBundleIcons</key>

--- a/dependencies/wawona/rust-backend-c2n.nix
+++ b/dependencies/wawona/rust-backend-c2n.nix
@@ -320,7 +320,7 @@ let
     # ── wawona (root crate) ────────────────────────────────────────
     wawona = attrs: {
       preConfigure = (attrs.preConfigure or "") + lib.optionalString pkgs.stdenv.isDarwin ''
-        export MACOSX_DEPLOYMENT_TARGET="26.0"
+        export MACOSX_DEPLOYMENT_TARGET="14.0"
       '';
       nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ [
         pkgs.pkg-config
@@ -540,7 +540,7 @@ let
       buildInputs = (attrs.buildInputs or []) ++
         lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
       preConfigure = (attrs.preConfigure or "") + lib.optionalString pkgs.stdenv.isDarwin ''
-        export MACOSX_DEPLOYMENT_TARGET="26.0"
+        export MACOSX_DEPLOYMENT_TARGET="14.0"
       '';
     };
 


### PR DESCRIPTION
Users shouldn't need Nix installed to use Wawona. Downloadable binaries on the Releases page lower the barrier to adoption. These are not the official signed versions, but they work.

See #43 for complementary App Store/Play Store publishing via Fastlane.

 - Add GitHub Actions workflow that creates GitHub Releases on tag push (`v*`)
 - macOS: builds via Nix, packages as `.dmg` with drag-to-install
 - Android: builds via Nix, attaches `.apk`
 - Reuses existing CI patterns (`nix-retry.sh`, same Nix config, same runner images)
 - No secrets required — uses built-in `GITHUB_TOKEN` (Needs write permission enabled)
 - Pre-release detection for versions containing `-` (e.g., `v0.3.0-rc1`)

  Also fixes three build bugs discovered while testing:

  - **Pinned weston header fetches to tagged releases** — `fetchurl` calls for
    linux input headers and libdrm headers pointed at `master`/`main` branches,
    causing hash mismatches when upstream changed. Pinned to `v6.6` and
    `libdrm-2.4.124`.

  - **Fixed Kotlin compilation error in MachineHomeScreen** — `FlowRow` requires
    `OptIn(ExperimentalLayoutApi::class)` on its enclosing composables, causing
    `:app:compileDebugKotlin` to fail.

  - **Lowered macOS deployment target from 26.0 to 14.0** — the app was built
    with `LSMinimumSystemVersion=26.0` (macOS Tahoe beta), preventing it from
    running on current macOS releases. Lowered to 14.0 (Sonoma).

  ## Test plan

 - [ ] Push a test tag (`v0.2.3-test`) to verify workflow runs
 - [ ] Verify `.dmg` opens and contains `Wawona.app` with Applications symlink
 - [ ] Verify `.apk` installs on Android device/emulator
 - [ ] Delete test tag/release after verification