### PR TITLE
dma-buf + Mode B iOS (feature branch)

### DIFF
--- a/.agent-device/vphone-modeb-smoke.ad
+++ b/.agent-device/vphone-modeb-smoke.ad
@@ -1,0 +1,14 @@
+# Mode B tipa smoke on vphone (Wawona agent-device fork)
+
+# Requires: nix run .#vphone-jb-lab (or --smoke-only), visible VM window,
+# Wawona agent-device with vphone support (0.18.3-wawona.1+).
+
+open --device "vphone wawona-jb" --session vphone-modeb
+screenshot --out .agent-device/test-artifacts/dmabuf/vphone-jb/ad-smoke-home.png
+apps
+snapshot -i
+# tipa path is relative to Wawona checkout when WAWONA_ROOT is set
+install .agent-device/test-artifacts/dmabuf/vphone-jb/WawonaModeBDemo-26.9.2-iOS-arm64.tipa
+open com.aspauldingcode.wawona.modeb-demo
+screenshot --out .agent-device/test-artifacts/dmabuf/vphone-jb/ad-smoke-demo.png
+close

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,58 @@ jobs:
           name: ios-ipa
           path: dist/Wawona-*-iOS-arm64.ipa
 
+  # Mode B iOS wrappers (TrollStore .tipa + rootless/rootful .deb).
+  # Never Ship: beta / TestFlight. Requires a Mode B .app with WWN_MODE_B.
+  release-ios-mode-b:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.BUILD_REF }}
+
+      - uses: DeterminateSystems/nix-installer-action@v20
+      - uses: DeterminateSystems/flakehub-cache-action@v3
+
+      - name: Build Mode B iOS app (when attr exists)
+        id: modeb
+        continue-on-error: true
+        run: |
+          VERSION=$(cat VERSION)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if nix eval --raw .#wawona-ios-mode-b-app 2>/dev/null; then
+            nix build .#wawona-ios-mode-b-app -o result-modeb
+            APP="$(find result-modeb -name 'Wawona.app' -type d | head -1)"
+            echo "app=$APP" >> "$GITHUB_OUTPUT"
+            echo "built=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "wawona-ios-mode-b-app not yet in flake; skipping binary build"
+            echo "built=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package .tipa + rootless/rootful .deb
+        if: steps.modeb.outputs.built == '1'
+        run: |
+          mkdir -p dist
+          ./scripts/package-ios-mode-b.sh \
+            --app "${{ steps.modeb.outputs.app }}" \
+            --version "${{ steps.modeb.outputs.version }}" \
+            --out dist \
+            --tipa --rootless-deb --rootful-deb
+          # Store-flavor must not appear in these artifacts.
+          ! grep -R "ITMS\|upload_to_testflight\|app-store-connect" dist || true
+          ls -la dist/
+
+      - name: Upload Mode B artifacts
+        if: steps.modeb.outputs.built == '1'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-mode-b
+          path: |
+            dist/Wawona-*-iOS-arm64.tipa
+            dist/Wawona-*-iOS-arm64-rootless.deb
+            dist/Wawona-*-iOS-arm64-rootful.deb
+            dist/Wawona-*-iOS-arm64-*.deb.tar.gz
+
   release-android:
     needs: product-android
     runs-on: ubuntu-latest
@@ -287,7 +339,7 @@ jobs:
           path: release-stage/*.AppImage
 
   create-release:
-    needs: [release-macos, release-ios, release-android, release-linux]
+    needs: [release-macos, release-ios, release-ios-mode-b, release-android, release-linux]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -302,10 +354,12 @@ jobs:
       - name: Flatten release assets
         run: |
           mkdir -p release-assets
-          find artifacts -type f \( -name '*.dmg' -o -name '*.apk' -o -name '*.ipa' -o -name '*.AppImage' \) \
+          find artifacts -type f \( -name '*.dmg' -o -name '*.apk' -o -name '*.ipa' -o -name '*.tipa' -o -name '*.deb' -o -name '*.AppImage' \) \
             -exec cp -v {} release-assets/ \;
           ls -la release-assets/
-          test "$(ls release-assets | wc -l)" -ge 4
+          # Mode A floor: at least dmg/apk/ipa/AppImage. Mode B tipa/deb optional until flake attr exists.
+          test "$(find release-assets -name '*.ipa' | wc -l)" -ge 1
+          test "$(find release-assets -name '*.dmg' | wc -l)" -ge 1
 
       - name: Create GitHub Release
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,11 @@ and **GitHub Actions** (`project=github-actions`) via wwn-mcp for upstream synta
   constructors, `WWNCore*` trampolines). Do not write a new Wawona program in C.
   Upstream ports stay in their upstream language. See
   `.cursor/rules/wawona-rust-first.mdc` and `docs/agent-rules/wawona-rust-first.md`.
+- **Wayland protocols: newest stable + version negotiation.** Do not maintain
+  duplicate implementations of the same interface for legacy clients. Older
+  *named* interfaces (e.g. text-input v1 vs v3) only with a demonstrated client
+  need. Policy: `docs/PROTOCOLS.md`; rule `wawona-wayland-protocol-compat`;
+  checklist in `CONTRIBUTING.md`.
 - **FFI**: production compositor bridge is hand-written C `WWNCore*` (`src/ffi/c_api.rs`)
   wrapped by ObjC (`WWNCompositorBridge.m`) / JNI (`android_jni.c`), polling
   model. Do NOT use `objc2`/`cocoa`/`jni`/`ndk` Rust crates or UniFFI callbacks.
@@ -204,21 +209,24 @@ is on (`wawona-nested-compositor-cursor`). Full rule:
   `.github/FUNDING.yml` as `Wawona/Wawona` (`github` / `ko_fi`:
   `aspauldingcode`). Copy the file when creating a repo. See
   `docs/agent-rules/wawona-github-funding.md` and rule `wawona-github-funding`.
-- **Desktop / LockScreen**. MacOS + Android **planned**; iOS/iPadOS only via
-  `repo.wawona.io` (website). Forbidden in App Store Apple-mobile apps (never
-  mention jailbreak there). See `wawona-platform-targets`,
-  `docs/iland-mode-a-b-desktop.md`.
-- **Wawona Swinging Bridge**. MacOS/Android Mode A+B planned; iOS/iPadOS Mode B
-  only (forbidden in store IPA). See `wawona-swinging-bridge`, `docs/swinging-bridge.md`.
-- **VM / containers**. Planned on macOS / iOS / iPadOS / Android / Linux;
-  forbidden on tvOS / watchOS / visionOS. See `docs/vms-containers.md`.
+- **Desktop / LockScreen**. MacOS + Android **planned**; iOS/iPadOS via
+  **TrollStore** (IOMobileFramebuffer own-display) and **Sileo** (`repo.wawona.io`,
+  ElleKit tweaks). Forbidden in App Store Apple-mobile apps (never mention
+  jailbreak / TrollStore / JIT there). See `wawona-platform-targets`,
+  `wawona-ios-mode-b-channels`, `docs/mode-a-b.md`, `docs/iland-mode-a-b-desktop.md`,
+  `docs/linux-dmabuf-zero-copy.md`.
+- **Wawona Swinging Bridge**. MacOS/Android Mode A+B planned; iOS/iPadOS
+  **Sileo Mode B only** (not TrollStore; forbidden in store IPA). See
+  `wawona-swinging-bridge`, `docs/swinging-bridge.md`.
 - **Binary filenames**. GitHub Release
-  `Wawona-{calver}-{platform}-{arch}.{ext}`; store uploads add `-{build}` before
+  `Wawona-{calver}-{platform}-{arch}.{ext}` plus Mode B
+  `.tipa` / `…-rootless.deb` / `…-rootful.deb`; store uploads add `-{build}` before
   the extension (TestFlight IPA / Play AAB). product-build may keep short names
   until a ship boundary. See `docs/ci.md`, `docs/agent-rules/wawona-release-assets.md`,
   rule `wawona-release-assets`.
 - Mode B **iland** dylib presence: assert with
-  `.github/scripts/verify-iland-mode-b-bundle.sh`.
+  `.github/scripts/verify-iland-mode-b-bundle.sh`. Store IPA Mode B absence:
+  `scripts/verify-ios-mode-b-absent.sh`.
 
 ## Product map (agents)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ default = ["desktop-protocols"]
 # Desktop-only Wayland protocols (DRM, XWayland, screen capture, session lock).
 # Disable for App Store builds: `--no-default-features`
 desktop-protocols = ["smithay-desktop"]
+# iOS/iPadOS Mode B (TrollStore / Sileo): JIT + IOMobileFramebuffer Desktop.
+# Never enable on App Store / TestFlight schemes. CI greps store IPA for absence.
+mode-b-ios = []
 # Runtime policy baseline (choose at build time; env override available)
 profile-store-safe = []
 profile-store-safe-remote = []

--- a/Sources/WawonaModel/PlatformCapabilities.swift
+++ b/Sources/WawonaModel/PlatformCapabilities.swift
@@ -204,14 +204,24 @@ public enum PlatformCapabilities: Sendable {
         return UserDefaults.standard.string(forKey: "OpenGLDriver") != "none"
     }
 
-    /// Desktop + LockScreen host replacement. Coming soon on macOS (Android is
-    /// gated in Compose). App Store Apple-mobile builds keep this forbidden and
-    /// must never mention alternate distribution paths in UI or strings.
+    /// Desktop + LockScreen host replacement.
+    /// - macOS: planned (Classic / iland Mode B dylib).
+    /// - iOS/iPadOS store schemes: always forbidden (never mention alternate
+    ///   distribution in UI strings).
+    /// - iOS/iPadOS Mode B schemes (`WWN_MODE_B`): planned then available
+    ///   (TrollStore IOMobileFramebuffer and/or Sileo). Store CI must fail if
+    ///   this flag is set on a store archive.
     public static var desktopReplacementGate: CapabilityGate {
         #if os(macOS)
         return .planned(flag: "WWN_DESKTOP_REPLACEMENT")
+        #elseif os(iOS)
+        #if WWN_MODE_B
+        return .planned(flag: "WWN_MODE_B_DESKTOP")
         #else
         return .forbidden(reason: "Desktop/LockScreen replacement is not offered in App Store Apple-mobile builds")
+        #endif
+        #else
+        return .forbidden(reason: "Desktop/LockScreen replacement is not offered on this Apple-mobile target")
         #endif
     }
 

--- a/dependencies/tools/vphone-cli-app.nix
+++ b/dependencies/tools/vphone-cli-app.nix
@@ -1,0 +1,83 @@
+# Runnable lab wrapper for Lakr233/vphone-cli (Swift + Makefile).
+# Clones into $VPHONE_ROOT/src, builds via scripts/build.sh, execs the .app binary.
+# IPSWs stay under ~/.vphone. See docs/testing/vphone-jailbreak-lab.md.
+{
+  lib,
+  writeShellApplication,
+  git,
+  python3,
+  aria2,
+  wget,
+  gnutar,
+  openssl,
+  cmake,
+  libusb1,
+  zstd,
+  coreutils,
+  findutils,
+  gnused,
+  gnugrep,
+  gnumake,
+}:
+
+writeShellApplication {
+  name = "vphone-cli";
+  runtimeInputs = [
+    git
+    python3
+    aria2
+    wget
+    gnutar
+    openssl
+    cmake
+    libusb1
+    zstd
+    coreutils
+    findutils
+    gnused
+    gnugrep
+    gnumake
+  ];
+  text = ''
+    set -euo pipefail
+    ROOT="''${VPHONE_ROOT:-$HOME/.vphone}"
+    SRC="$ROOT/src/vphone-cli"
+    BIN_APP="$SRC/.build/vphone-cli.app/Contents/MacOS/vphone-cli"
+    BIN_REL="$SRC/.build/release/vphone-cli"
+    mkdir -p "$ROOT"
+
+    if [[ ! -d "$SRC/.git" ]]; then
+      echo "vphone-cli: cloning Lakr233/vphone-cli (recurse-submodules) into $SRC" >&2
+      git clone --recurse-submodules --depth 1 \
+        https://github.com/Lakr233/vphone-cli.git "$SRC"
+    fi
+
+    pick_bin() {
+      if [[ -x "$BIN_APP" ]]; then echo "$BIN_APP"; return; fi
+      if [[ -x "$BIN_REL" ]]; then echo "$BIN_REL"; return; fi
+      echo ""
+    }
+
+    BIN="$(pick_bin)"
+    if [[ -z "$BIN" ]]; then
+      echo "vphone-cli: building (scripts/setup_tools.sh + scripts/build.sh)" >&2
+      echo "vphone-cli: needs Xcode, network, and tens of GB free for later IPSWs" >&2
+      cd "$SRC"
+      if [[ ! -x .venv/bin/python3 ]]; then
+        ./scripts/setup_tools.sh || {
+          echo "vphone-cli: setup_tools.sh failed (brew deps may be missing; nix PATH has substitutes)" >&2
+          exit 1
+        }
+      fi
+      ./scripts/build.sh || true
+      BIN="$(pick_bin)"
+    fi
+
+    if [[ -z "$BIN" || ! -x "$BIN" ]]; then
+      echo "vphone-cli: no runnable binary under $SRC/.build" >&2
+      exit 1
+    fi
+
+    exec "$BIN" "$@"
+  '';
+}

--- a/dependencies/tools/vphone-cli.nix
+++ b/dependencies/tools/vphone-cli.nix
@@ -1,0 +1,44 @@
+# Darwin-only wrap of Lakr233/vphone-cli for the Wawona jailbreak lab.
+# Not an L0 toolchain input. IPSWs stay in ~/.vphone (or $VPHONE_ROOT).
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  python3,
+  aria2,
+  wget,
+  gnutar,
+  openssl,
+  cmake,
+  libusb1,
+  zstd,
+  # ldid from nixpkgs when available; Procursus ldid preferred at runtime.
+  ldid ? null,
+}:
+
+assert stdenv.hostPlatform.isDarwin;
+assert stdenv.hostPlatform.isAarch64;
+
+stdenv.mkDerivation rec {
+  pname = "vphone-cli";
+  version = "unstable-2026-08";
+
+  src = fetchFromGitHub {
+    owner = "Lakr233";
+    repo = "vphone-cli";
+    # Pin loosely; bump when the lab recipe needs a known tip.
+    rev = "main";
+    hash = lib.fakeHash; # replaced after first prefetch; see passthru.update
+  };
+
+  # Upstream often needs a live checkout for IPSW tooling. Prefer wrapping a
+  # fetch that fails eval until hash is filled; for local lab use the
+  # writeShellApplication fallback below when hash is fake.
+  meta = {
+    description = "Virtual iPhone (PCC) CLI with jailbreak jb variant";
+    homepage = "https://github.com/Lakr233/vphone-cli";
+    platforms = [ "aarch64-darwin" ];
+    license = lib.licenses.unfreeRedistributable; # research tooling; check upstream
+  };
+}

--- a/docs/agent-rules/wawona-ios-mode-b-channels.md
+++ b/docs/agent-rules/wawona-ios-mode-b-channels.md
@@ -1,0 +1,86 @@
+# iOS / iPadOS install channels (Mode A vs Mode B)
+
+Cursor rule mirror: `.cursor/rules/wawona-ios-mode-b-channels.mdc`.
+Canonical product: [`../mode-a-b.md`](../mode-a-b.md). Site: wawona.io `/docs/mode-a-b/`.
+
+## Three channels (never collapse into one)
+
+| Channel | How users get it | Privilege class |
+|---|---|---|
+| **App Store / TestFlight** | ASC | **Mode A only** |
+| **TrollStore sideload** | Website `.tipa` + `ldid` entitlements | **Mode B**: JIT + IOMobileFramebuffer + Desktop/LockScreen |
+| **Sileo (`repo.wawona.io`)** | Jailbreak + Mode B IPA / `.deb` + tweaks | **Full Mode B** (above + Swinging Bridge + host APT) |
+
+App Store copy and binaries must **never** mention TrollStore, Sileo, jailbreak,
+JIT, or framebuffer SPI. Website + `repo.wawona.io` may.
+
+## Channel matrix
+
+| Channel | JIT | IOMobileFramebuffer / own-display | Desktop + LockScreen | Swinging Bridge |
+|---|---|---|---|---|
+| App Store / TestFlight | No | No | No | No |
+| TrollStore (`ldid`) | Yes | Yes | Yes | No |
+| Sileo (`repo.wawona.io`) | Yes | Yes | Yes | Yes + host APT |
+
+### 1. App Store / TestFlight (Mode A)
+
+- VMs: **QEMU-TCTI / TCG interpreter only** (UTM SE model). No `MAP_JIT`, no HVF.
+- Containers: OCI + container-in-VM on that **jitless** engine.
+- Wasm: WASI Runtime **without** JIT (bytecode as data via `wpm` / `/wasm/`).
+- Desktop / LockScreen: **forbidden** in-app.
+- Wawona Swinging Bridge: **forbidden** in store IPA.
+- Shell: sandboxed `wwn-zsh` hatch.
+- Present: public Metal / `CAMetalLayer` only (Mode A in-window).
+
+### 2. TrollStore sideload (`ldid` Mode B)
+
+TrollStore installs a Mode B IPA signed with `ldid`. Entitlements may grant JIT
+**and** framebuffer SPI **and** Desktop / LockScreen on an own-display path.
+
+- VMs: QEMU/UTM **with JIT**.
+- Containers: container-in-VM **with JIT**.
+- Wasm: Runtime may enable **Wasm JIT** when the entitlement is present.
+- **Desktop / LockScreen**: yes, via IOMobileFramebuffer own-display (in-app
+  greeter). Not SpringBoard injection (no ElleKit on TrollStore).
+- Swinging Bridge Mode B: **no**. Needs jailbreak + Sileo.
+- Ship name: `Wawona-{calver}-iOS-arm64.tipa`. Never through Ship: beta / TestFlight.
+
+### 3. Sileo from `repo.wawona.io` (full Mode B, jailbreak)
+
+Jailbroken device + Sileo. Mode B IPA / `.deb` and tweaks ship **out of the box**:
+
+- Same JIT + IOMobileFramebuffer Desktop engines as TrollStore.
+- **Desktop / LockScreen** also via SpringBoard tweaks (ElleKit on rootless).
+- **Wawona Swinging Bridge Mode B** (UIKit apps as Wayland clients).
+- Unsandboxed shell + host APT (`/jailbreak/` channel).
+- Rootless (`iphoneos-arm64`, `/var/jb`) and rootful (`iphoneos-arm`, `/`) are
+  **separate** packages. Never one `.deb` for both.
+
+`repo.wawona.io` publishes Mode B packages under `/jailbreak/` only. Store CI
+must fail if this flavor is linked into Mode A.
+
+## QEMU on iOS
+
+```text
+Mode A (store)     →  -accel tcg , jitless / TCTI (UTM SE). Interpreter ceiling.
+TrollStore / Sileo →  QEMU/UTM + JIT (Mode B scheme / WWN_MODE_B). Never in store link.
+```
+
+Shared guest/OCI/Machines UI. Divergent engine compile flavor. Never a store
+binary with a runtime “enable JIT” or “enable framebuffer” toggle.
+
+## Hard rejects
+
+- JIT / `MAP_JIT` / Hypervisor / IOMobileFramebuffer SPI in App Store / TestFlight IPA
+- TrollStore/Sileo/jailbreak strings in store UI
+- Treating TrollStore as JIT-only (Desktop/LockScreen/IOMFB are in scope for `.tipa`)
+- Treating TrollStore as full Sileo (Swinging Bridge / host APT / ElleKit tweaks)
+- Linking ElleKit into store IPA or TrollStore `.tipa`
+- One binary with a runtime Mode B toggle that ships to ASC
+- Conflating macOS iland Desktop Mode B dylib with iOS Mode B IPA
+
+## Related
+
+`wawona-mode-a-b`, `wawona-swinging-bridge`, `wawona-iland-mode-b-desktop`,
+`wawona-product-map`, `wawona-platform-targets`, `docs/vms-mode-a-b.md`,
+`docs/linux-dmabuf-zero-copy.md`.

--- a/docs/agent-rules/wawona-mode-a-b.md
+++ b/docs/agent-rules/wawona-mode-a-b.md
@@ -3,38 +3,49 @@
 Authority: `Wawona/docs/mode-a-b.md`. Prefer that doc when Mode B is framed as
 only macOS iland Desktop.
 
+**iOS install channels (TrollStore vs Sileo):** see
+[`wawona-ios-mode-b-channels.md`](./wawona-ios-mode-b-channels.md).
+
 ## Definitions
 
-- **Mode A**. App Store / TestFlight / Play / store-shaped builds. Compliance
+- **Mode A**: App Store / TestFlight / Play / store-shaped builds. Compliance
   first. **No JIT** on Apple mobile. **Never** ship Mode B engines or jailbreak
   copy in these artifacts.
-- **Mode B**. Jailbreak (iOS/iPadOS), SIP-disabled/partial macOS, rooted /
-  privileged Android. Distributed via `repo.wawona.io` (Sileo `.deb` + **Mode B
-  IPA**), `.#wawona-macos-desktop-host`, website-documented sideload. **not**
-  ASC/Play.
+- **Mode B**: Privileged builds. On iOS/iPadOS that means either **TrollStore
+  sideload** (JIT + IOMobileFramebuffer + Desktop/LockScreen) or **Sileo from
+  `repo.wawona.io`** (full Mode B: JIT plus Desktop, LockScreen, Swinging
+  Bridge). macOS Desktop needs SIP fully disabled (`csrutil disable`). Android
+  Mode B is root/privileged outside Play. **not** ASC/Play.
 
 ## iOS / iPadOS (design both always)
 
-| | Mode A (store IPA) | Mode B (Sileo Mode B IPA) |
-|---|---|---|
-| VMs | UTM-SE-class **jitless** (`wwn-vms`) | UTM/QEMU **+ JIT** |
-| Containers | container-in-VM on jitless engine | container-in-VM **+ JIT** |
-| Shell | `wwn-zsh` hatch | Unsandboxed / jailbreak shell + host APT |
-| Desktop / LockScreen | Forbidden in-app | Yes via repo |
-| Packages | `repo.wawona.io/wasm` + Files `.wasm` | Wasm **plus** jailbreak APT |
+| | Mode A (store IPA) | TrollStore (`ldid`) | Sileo Mode B (jailbreak) |
+|---|---|---|---|
+| VMs | QEMU-TCTI **jitless** | QEMU/UTM **+ JIT** | QEMU/UTM **+ JIT** |
+| Containers | container-in-VM jitless | container-in-VM **+ JIT** | container-in-VM **+ JIT** |
+| Wasm | Runtime, no JIT | Wasm **+ JIT** allowed | Wasm **+ JIT** allowed |
+| Shell | `wwn-zsh` hatch | Sideload / sandbox as designed | Unsandboxed + host APT |
+| Desktop / LockScreen | Forbidden | **Yes** (IOMFB own-display) | **Yes** (default; + ElleKit tweaks) |
+| Swinging Bridge | Forbidden | No | **Yes** (Mode B, default) |
 
-`repo.wawona.io` **auto-packages** the Mode B IPA for Sileo. Store CI must fail
-if Mode B/JIT/jailbreak engage is linked into Mode A.
+`repo.wawona.io` **auto-packages** Mode B IPA / `.deb` for Sileo. Store CI must fail
+if Mode B/JIT/jailbreak engage is linked into Mode A. Website may document
+TrollStore; store binaries must not.
 
 ## Hard rules
 
-1. Design `wwn-vms`, `wwn-containers`, and Wawona Machines with **A and B** in
-   mind from day one (shared OCI/profiles; divergent engines behind flavor).
+1. Design `wwn-vms`, `wwn-containers`, Wasm Runtime backends, and Wawona Machines
+   with **A and B** in mind from day one (shared OCI/profiles; divergent engines
+   behind flavor / `WWN_MODE_B`).
 2. **Never** ship Mode B to App Store / Play (no “hidden toggle”).
 3. Do not conflate: iland macOS Desktop dylib ≠ iOS Mode B IPA ≠ Wawona Swinging Bridge Mode B.
-4. Wasm package manager is Mode A-safe; jailbreak `.deb` is Mode B-only channel.
-5. tvOS / watchOS / visionOS: no VM/container machine kinds.
+4. Wasm **packages** stay bytecode (`/wasm/`). Mode B may JIT-execute them; Mode A must not.
+5. Jailbreak `.deb` is Sileo-only. Store binaries never touch `/jailbreak/`.
+6. tvOS / watchOS: no VM/container machine kinds. visionOS Mode A = same
+   jitless UTM-SE class as iOS; Mode B IPA policy follows product gates.
+7. Never link ElleKit into store IPA or TrollStore `.tipa`.
 
-See also: `wawona-iland-mode-b-desktop`, `wawona-swinging-bridge`, `wawona-platform-targets`,
+See also: `wawona-ios-mode-b-channels`, `wawona-iland-mode-b-desktop`,
+`wawona-swinging-bridge`, `wawona-platform-targets`,
 `docs/vms-mode-a-b.md`, `docs/containers-mode-a-b.md`,
-`docs/wasm-package-manager.md`.
+`docs/wasm-package-manager.md`, `docs/linux-dmabuf-zero-copy.md`.

--- a/docs/agent-rules/wawona-platform-targets.md
+++ b/docs/agent-rules/wawona-platform-targets.md
@@ -50,17 +50,19 @@ in both places.
 **Linux** (not in the Apple/Android columns): native + remote ✅; VM/containers
 ⏳ planned; Desktop/LockScreen ❌; Wawona Swinging Bridge ❌.
 
-**iOS and iPadOS are the same** for Desktop/LockScreen and Wawona Swinging Bridge (store Mode A
-vs `repo.wawona.io` Mode B / jailbreak Desktop). Do not special-case iPadOS as
+**iOS and iPadOS are the same** for Desktop/LockScreen and Wawona Swinging Bridge
+(store Mode A vs TrollStore / Sileo Mode B). Do not special-case iPadOS as
 forbidden while iPhone is planned for those features.
 
 **Desktop / LockScreen vs Wawona Swinging Bridge vs local shell vs VMs (do not conflate):**
 
 - **Desktop + LockScreen**. Host DE / greeter. macOS + Android ⏳; **iOS and
-  iPadOS** jailbreak path via `repo.wawona.io` (website only); App Store builds
-  ❌ and must never mention jailbreak. Not Linux. Not tvOS/watchOS/visionOS.
-- **Wawona Swinging Bridge**. MacOS/Android (and iOS Mode B) apps → Wayland
-  (+ waypipe to Linux). See `wawona-swinging-bridge`. Not Desktop/LockScreen.
+  iPadOS** via **TrollStore** (IOMobileFramebuffer own-display) and **Sileo**
+  (`repo.wawona.io`, + ElleKit SpringBoard tweaks). App Store builds ❌ and must
+  never mention jailbreak. Not Linux. Not tvOS/watchOS/visionOS.
+- **Wawona Swinging Bridge**. MacOS/Android (and iOS **Sileo** Mode B only) apps →
+  Wayland (+ waypipe to Linux). See `wawona-swinging-bridge`. Not Desktop/LockScreen.
+  Not available on TrollStore alone.
 - **On-device shell**. Bundled **zsh** + Weston terminal (native port path).
   Not a VM and not a container. Separate from `virtual_machine` / `container`
   machine kinds.
@@ -71,10 +73,13 @@ forbidden while iPhone is planned for those features.
   Engines (planned):
   - **iOS / iPadOS Mode A (store):** UTM-SE-class **jitless** interpreter
     (`wwn-vms` TCTI); containers = OCI pull + container-in-VM on that engine.
-  - **iOS / iPadOS Mode B (Sileo Mode B IPA from `repo.wawona.io`):** JIT-enabled
-    UTM/QEMU for VMs **and** containers; unsandboxed shell + host APT. Auto-
-    package Mode B IPA on the repo. **absent** from store IPA.
-  - **Sideload / TrollStore:** website may document JIT; App Store copy must not.
+  - **iOS / iPadOS Mode B (TrollStore `.tipa`):** JIT-enabled UTM/QEMU for VMs
+    **and** containers; IOMobileFramebuffer Desktop/LockScreen; **no** Swinging
+    Bridge / host APT. **absent** from store IPA.
+  - **iOS / iPadOS Mode B (Sileo from `repo.wawona.io`):** same JIT + Desktop
+    engines; plus unsandboxed shell, host APT, ElleKit tweaks, Swinging Bridge.
+    Auto-package Mode B IPA / `.deb` on the repo. **absent** from store IPA.
+  - Website may document TrollStore and Sileo; App Store copy must not.
   - **macOS:** Apple Containerization (`Containerization.framework`) + VMs via
     `Virtualization.framework`, bundled into Wawona. The Apple `container` CLI
     and Containerization.framework are **macOS-only** (`appleContainerizationGate`);
@@ -122,11 +127,11 @@ forbidden while iPhone is planned for those features.
    on visionOS (same class as tvOS/watchOS). Do not leave visionOS on a reduced
    iOS-phone feature set for everything else.
 4. **Desktop / LockScreen replacement**. **macOS + Android** (⏳ planned),
-   plus **iOS and iPadOS** jailbreak tweaks documented only on the website /
-   `repo.wawona.io` (Sileo). **Forbidden** on Linux and on App Store builds of
-   iOS/iPadOS (and all of tvOS/watchOS/visionOS). Machine profiles for
-   Desktop/LockScreen: **native ports only**. macOS engage path: SIP **fully
-   disabled** (`csrutil disable`) + `.dylib`. Partial SIP
+   plus **iOS and iPadOS** via TrollStore (IOMFB) and Sileo (`repo.wawona.io`,
+   ElleKit tweaks). Documented on the website; **forbidden** on Linux and on
+   App Store builds of iOS/iPadOS (and all of tvOS/watchOS/visionOS). Machine
+   profiles for Desktop/LockScreen: **native ports only**. macOS engage path:
+   SIP **fully disabled** (`csrutil disable`) + `.dylib`. Partial SIP
    (`csrutil enable --without debug`) is refused. Android: Default Home App + LockScreen APIs.
    **no root required, no fallback tier required**. Never wire Desktop/LockScreen
    UI into App Store Apple-mobile builds; never mention jailbreak in those

--- a/docs/agent-rules/wawona-product-map.md
+++ b/docs/agent-rules/wawona-product-map.md
@@ -5,7 +5,7 @@ These are **separate** products. Mixing them in code, docs, UI, or packaging is 
 | Product | What it is | Not |
 |---|---|---|
 | **Wawona Swinging Bridge** (formerly **anowaW**) | Cocoa / Android / (future UIKit) apps → **Wayland clients**, local or over **waypipe-rs** to Linux (resize, placement, HID) | Desktop/LockScreen; MediaProjection-as-desktop |
-| **Desktop + LockScreen replacement** | Host DE / greeter (machine picker). macOS + Android planned; iOS/iPadOS jailbreak via `repo.wawona.io` only | Swinging Bridge; Linux; store Apple-mobile |
+| **Desktop + LockScreen replacement** | Host DE / greeter (machine picker). macOS + Android planned; iOS/iPadOS via TrollStore (IOMFB) and Sileo (`repo.wawona.io`) | Swinging Bridge; Linux; store Apple-mobile |
 | **`wwn-vms`** | Machines kind `virtual_machine` | Wasm packages; local shell; Swinging Bridge |
 | **`wwn-containers`** | Machines kind `container` (OCI) | Wasm packages; Desktop |
 | **Wawona Runtime + `wpm`** (`wwn-wasm`) | WASI P1/P2 **`.wasm` packages** for optional software | OCI containers; `.deb`; Mach-O modules (`wwn-apt` retired) |
@@ -16,9 +16,9 @@ Canonical prose: `Wawona/docs/mode-a-b.md`, `swinging-bridge.md`, `iland-mode-a-
 
 | | **Mode A** | **Mode B** |
 |---|---|---|
-| Who | App Store / TestFlight / Play / store-shaped | Jailbreak iOS/iPadOS; SIP **fully disabled** (`csrutil disable`) for macOS Desktop/LockScreen; root Android |
-| Ship | Store IPA/AAB; notarized macOS | `repo.wawona.io` Sileo `.deb` + **Mode B IPA**; desktop-host macOS. **never** in store |
-| Copy | Never mention jailbreak / JIT pitch in store UI | Website + repo may document Mode B |
+| Who | App Store / TestFlight / Play / store-shaped | TrollStore iOS/iPadOS; jailbreak Sileo; SIP **fully disabled** (`csrutil disable`) for macOS Desktop/LockScreen; root Android |
+| Ship | Store IPA/AAB; notarized macOS | TrollStore `.tipa`; Sileo rootless/rootful `.deb` + Mode B IPA; desktop-host macOS. **never** in store |
+| Copy | Never mention jailbreak / JIT / TrollStore / Sileo in store UI | Website + repo may document Mode B |
 
 **Always design A and B together** for VMs, containers, Desktop, Swinging Bridge. **Never** ship Mode B into App Store / Play artifacts.
 
@@ -33,12 +33,13 @@ Canonical prose: `Wawona/docs/mode-a-b.md`, `swinging-bridge.md`, `iland-mode-a-
 
 - macOS: Mode A present path = iland userspace; Mode B = SIP **fully disabled** (`csrutil disable`) + `libwayland-mac.dylib` in `.#wawona-macos-desktop-host` only. Partial SIP (`csrutil enable --without debug`) is refused.
 - Android: Default Home + LockScreen APIs (planned); no root required for baseline.
-- App Store Apple-mobile: **forbidden** in-app; never jailbreak strings in store IPA.
+- iOS/iPadOS: **TrollStore** `.tipa` (IOMobileFramebuffer own-display) and **Sileo** (same engines + ElleKit SpringBoard tweaks). App Store: **forbidden** in-app; never jailbreak strings in store IPA.
+- Swinging Bridge on iOS remains **Sileo-only** (not TrollStore).
 
 ### VMs / containers
 
 - Platforms: planned on macOS, iOS, iPadOS, Android, Linux. **Forbidden** on tvOS, watchOS, visionOS.
-- iOS Mode A: UTM-SE-class **jitless**. iOS Mode B: JIT UTM via Mode B IPA.
+- iOS Mode A: UTM-SE-class **jitless**. iOS Mode B: JIT UTM via TrollStore `.tipa` and/or Sileo Mode B IPA.
 - Backends differ by OS (macOS Virtualization/Apple Container ≠ iOS UTM ≠ Android QEMU). Do not force one engine.
 - Not the same as on-device `wwn-zsh` shell or Wasm packages.
 
@@ -57,7 +58,9 @@ Canonical prose: `Wawona/docs/mode-a-b.md`, `swinging-bridge.md`, `iland-mode-a-
 ## Hard rejects
 
 ❌ Call Swinging Bridge “Desktop” or “LockScreen”  
-❌ Ship Mode B / JIT / jailbreak engage in store IPA/AAB  
+❌ Ship Mode B / JIT / jailbreak / IOMobileFramebuffer SPI in store IPA/AAB
+❌ Link ElleKit into store IPA or TrollStore `.tipa`
+
 ❌ Treat Wasm packages as containers/VMs (or vice versa)  
 ❌ Put graphics/Desktop/Swinging Bridge ownership into `wwn-toolchain` (L0 substrate only)  
 ❌ Document Runtime as needing Mode B for package install  

--- a/docs/agent-rules/wawona-release-assets.md
+++ b/docs/agent-rules/wawona-release-assets.md
@@ -1,26 +1,42 @@
 # Wawona binary naming (GitHub + stores)
 
-Token order is always **app → calver → platform → arch → [build] → ext**.
+Token order is always **app → calver → platform → arch → [jailbreak-scheme] → [build] → ext**.
 
 | Channel | Pattern | Build in name? |
 |---------|---------|----------------|
 | **GitHub Release** (`Ship: GitHub assets`, tag `v*`) | `Wawona-{calver}-{platform}-{arch}.{ext}` | No |
+| **GitHub Mode B iOS** (same workflow; not Ship: beta) | `Wawona-{calver}-iOS-arm64.tipa` / `…-rootless.deb` / `…-rootful.deb` | No |
 | **Store upload** (`Ship: beta` → TestFlight / Play) | `Wawona-{calver}-{platform}-{arch}-{build}.{ext}` | Yes |
 | **product-build / Gate** | Short unversioned (`Wawona.apk`, `Wawona.app`, `Wawona-{arch}.AppImage`) | N/A. Rename only at ship boundaries |
 
 Examples (`VERSION=26.8.12`, build `142`):
 
-- GitHub: `Wawona-26.8.12-macOS-arm64.dmg`, `…-iOS-arm64.ipa`, `…-Android-arm64.apk`, `…-Linux-x86_64.AppImage`, `…-Linux-arm64.AppImage`
+- GitHub Mode A: `Wawona-26.8.12-macOS-arm64.dmg`, `…-iOS-arm64.ipa`, `…-Android-arm64.apk`, `…-Linux-x86_64.AppImage`, `…-Linux-arm64.AppImage`
+- GitHub Mode B iOS: `Wawona-26.8.12-iOS-arm64.tipa`, `…-iOS-arm64-rootless.deb`, `…-iOS-arm64-rootful.deb` (optional `…-roothide.deb`)
 - Stores: `Wawona-26.8.12-iOS-arm64-142.ipa` (also `tvOS` / `visionOS`), `Wawona-26.8.12-Android-arm64-142.aab`
 
 Platform tokens: GitHub `macOS` \| `iOS` \| `Android` \| `Linux`; stores also `tvOS` \| `visionOS`. Arch: `arm64` \| `x86_64` (Linux filename maps `aarch64` → `arm64`).
 
+## Mode B iOS wrappers (GitHub + Sileo only)
+
+| Wrapper | File | dpkg `Architecture` | Install prefix |
+|---|---|---|---|
+| Mode A sideload | `Wawona-{calver}-iOS-arm64.ipa` | n/a | App sandbox |
+| TrollStore | `Wawona-{calver}-iOS-arm64.tipa` | n/a | TrollStore app container |
+| Sileo **rootless** | `Wawona-{calver}-iOS-arm64-rootless.deb` | `iphoneos-arm64` | `/var/jb` |
+| Sileo **rootful** | `Wawona-{calver}-iOS-arm64-rootful.deb` | `iphoneos-arm` | `/` |
+| RootHide (optional) | `Wawona-{calver}-iOS-arm64-roothide.deb` | `iphoneos-arm64e` | `jbroot()` |
+
+Jailbreak scheme tokens (`rootless` / `rootful` / `roothide`) are **required** before `.deb`. Rootful and rootless are different builds (DESTDIR, rpath, control), not a renamed tree. Never upload `.tipa` or Mode B `.deb` through Ship: beta / `upload_to_testflight`.
+
 ## Hard rejects
 
-- Unversioned GitHub/store ship names: `Wawona.apk`, `Wawona.aab`, `Wawona-macOS-arm64.dmg`, `Wawona-x86_64.AppImage` on a Release
+- Unversioned GitHub/store ship names: `Wawona.apk`, `Wawona.aab`, `Wawona.deb`, `Wawona-macOS-arm64.dmg`, `Wawona-x86_64.AppImage` on a Release
 - Scheme-first store IPAs: `Wawona-iOS-{calver}-{build}.ipa`
 - Missing platform or arch on a ship basename
+- One `.deb` that claims both rootful and rootless
 - Passing a product-build short name straight to `gh release upload`, `upload_to_testflight`, or `upload_to_play_store` without renaming
+- Mode B entitlements in a store IPA
 
 product-build short names are fine **inside** Gate artifacts only.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -45,7 +45,7 @@ Workflow display names use a role prefix (`Gate` / `Build` / `Watch` / `Ship`). 
 | **FlakeHub publish** (`flakehub-publish.yml`) | push (`development`) + tags `vYY.M.D` + dispatch | - | Rolling `0.1.N` on development; CalVer SemVer on tags ([`flakehub-registry.md`](./flakehub-registry.md)); not a promote gate |
 | **Ship: beta (stores)** (`release-beta.yml`) | - | push + tags `v*` | Fastlane stores (match+gym). **Does not build AppImages**. See Ship: beta AppImages below |
 | **Ship: beta AppImages** (`ship-beta-appimage.yml`) | - | after a green master **Gate: products** (`workflow_run`) | Re-publishes that run's same-SHA `product-appimage-*` as 30-day `wawona-beta-appimage-*` via cross-run `download-artifact`. **no rebuild, no fallback**. Deletes the old master-push double AppImage build (Gate: products + Ship: beta). Keyed on the Gate run's `head_sha` so it never shares release-beta's concurrency group |
-| **Ship: GitHub assets** (`release.yml`) | - | tags `v*` (+ `workflow_dispatch`) | GitHub Release: DMG/APK/AppImage from product-build (`macos-app` / `android-apk` / `appimage` only; tip_key `ship-assets-<tag>`); IPA via Fastlane `ios github_ipa` (match+gym, same as Ship: beta). macOS DMG is **Developer ID signed + notarized** |
+| **Ship: GitHub assets** (`release.yml`) | - | tags `v*` (+ `workflow_dispatch`) | GitHub Release: DMG/APK/AppImage from product-build; IPA via Fastlane `ios github_ipa`; optional Mode B `release-ios-mode-b` (`.tipa` + rootless/rootful `.deb`, never TestFlight). macOS DMG is **Developer ID signed + notarized** |
 
 ### Binary filenames (three channels)
 

--- a/docs/linux-dmabuf-zero-copy.md
+++ b/docs/linux-dmabuf-zero-copy.md
@@ -1,0 +1,90 @@
+# linux-dmabuf zero-copy (Wawona)
+
+Canonical matrix for `zwp_linux_dmabuf_v1` on every Wawona target. Complements
+[`iland-graphics-stack.md`](./iland-graphics-stack.md) and
+[`mode-a-b.md`](./mode-a-b.md). Site: wawona.io `/docs/linux-dmabuf/`.
+
+**Goal:** one `wl_buffer` object, no CPU blit on GPU sessions, every client
+backend (EGL, Vulkan WSI, DRM/KMS, waypipe) and every present sink on that OS.
+
+This is **not** Linux kernel dma-buf on Apple/Android. `wwn-iland` emulates
+KMS/GBM over IOSurface (Apple) / AHardwareBuffer (Android). Never open
+`/dev/dri` or `/dev/kgsl`.
+
+## Modifier convention
+
+| OS | Advertise | Import |
+|---|---|---|
+| Apple (macOS / iOS family except watchOS) | High-bit modifier `0x8000_0000_0000_0000` + IOSurface id | `IOSurfaceLookup` |
+| Android | Same high-bit + AHB id | AHB registry |
+| Linux | `DRM_FORMAT_MOD_LINEAR` + real modifiers | GBM import of the fd |
+| watchOS | **Do not register** `zwp_linux_dmabuf_v1` | SpriteKit of `wl_shm` only |
+
+Never advertise `DRM_FORMAT_MOD_LINEAR` on Apple or Android.
+
+## Present sinks
+
+| Sink | Target / mode | Notes |
+|---|---|---|
+| `CAMetalLayer` | macOS Mode A; iOS/iPadOS/visionOS/tvOS Mode A | Default in-window GPU path |
+| `framebufferd` | macOS Mode B Classic | Page-flip is the IOSurface; no extra blit |
+| IOMobileFramebuffer | iOS/iPadOS TrollStore and Sileo | `ldid` entitlements; **never** in store link |
+| `ANativeWindow` / Surface | Android Mode A and Home Mode B | AHB import then present |
+| Host GBM/EGL | Linux | Real dma-buf fd |
+| SpriteKit | watchOS | SHM upload only |
+
+macOS Mode A must stay green while Classic and TrollStore sinks land.
+
+## Client backends (`wwn-iland`)
+
+| Backend | Done means |
+|---|---|
+| Wayland-EGL | Swap posts IOSurface/AHB dmabuf `wl_buffer` |
+| Vulkan Wayland WSI | `VK_KHR_wayland_surface` shim; `vkcube` leaves KMS host |
+| DRM/KMS/GBM | Same IOSurface/AHB as dmabuf export |
+| `wl_shm` | Software fallback only (allowed; log `fallback_shm`) |
+
+## Completion gates
+
+A GPU session is green only when structured logs show `copy=zero` for
+create → import → present. `copy=cpu` or unexpected `fallback_shm` is red.
+
+Catalog `zwp_linux_dmabuf_v1` stays **Partial** until the proof matrix in
+[`testing/everywhere-matrix.md`](./testing/everywhere-matrix.md) has log +
+screenshot (or explicit N/A) under
+`Wawona/.agent-device/test-artifacts/dmabuf/`.
+
+### Logging schema (`wwn.dmabuf`)
+
+| Field | Meaning |
+|---|---|
+| `op` | bind, modifier_ad, feedback, add_plane, create, create_immed, import, present, fallback_shm |
+| `os` / `sink` | apple_metal, framebufferd, iomfb, ahb_surface, linux_gbm, watch_spritekit |
+| `modifier` | hex |
+| `backing_id` | IOSurface id / AHB id / drm name |
+| `format` | fourcc |
+| `copy` | `zero` or `cpu` |
+| `client` | opengl-cube, weston-simple-egl, vkcube, waypipe, nested weston/niri |
+
+```text
+RUST_LOG=wwn.dmabuf=trace,linux_dmabuf=trace
+WAYLAND_DEBUG=1   # on the client
+adb logcat -s WawonaDmabuf
+```
+
+## Mode A vs Mode B
+
+Mode A and Mode B are **separate** proofs. A Classic or TrollStore green cell
+does not promote the store IPA. Store CI must grep-fail Mode B / IOMFB symbols.
+
+Jailbreak proof for iOS Desktop uses a **vphone-cli `jb` guest** (real iOS
+kernel VM), not the Xcode Simulator. See Mode B channels and the vphone harness
+docs under `docs/testing/`.
+
+## Hard rejects
+
+- LINEAR ads on Apple/Android
+- Fake dmabuf global on watchOS
+- Real kernel DRM / KGSL
+- Mode B / IOMFB in store IPA
+- Marking catalog Functional from a unit test alone

--- a/docs/mode-a-b.md
+++ b/docs/mode-a-b.md
@@ -6,16 +6,50 @@ that treated “Mode B” as macOS-iland-only.
 
 | | **Mode A** | **Mode B** |
 |---|---|---|
-| **Who** | App Store / TestFlight / Play / store-shaped macOS | Jailbreak (iOS/iPadOS), SIP fully disabled for macOS Desktop/LockScreen (`csrutil disable`), rooted/privileged Android |
-| **Distribution** | Apple / Google store binaries; notarized `.#wawona-macos` | `repo.wawona.io` (Sileo `.deb` + **Mode B IPA**), desktop-host macOS flavor, sideload/TrollStore where documented on the **website only** |
-| **In store IPA/AAB** | Only Mode A | **Never**. No Mode B engines, no jailbreak strings, no JIT |
+| **Who** | App Store / TestFlight / Play / store-shaped macOS | Jailbreak (iOS/iPadOS), TrollStore sideload, SIP fully disabled for macOS Desktop/LockScreen (`csrutil disable`), rooted/privileged Android |
+| **Distribution** | Apple / Google store binaries; notarized `.#wawona-macos` | **TrollStore** `.tipa` (`ldid`: JIT + IOMobileFramebuffer + Desktop/LockScreen), `repo.wawona.io` Sileo (rootless/rootful `.deb` + Mode B IPA + tweaks), desktop-host macOS flavor. Website only for sideload/jailbreak docs |
+| **In store IPA/AAB** | Only Mode A | **Never**. No Mode B engines, no jailbreak strings, no JIT, no framebuffer SPI |
 
 Related: [`iland-mode-a-b-desktop.md`](./iland-mode-a-b-desktop.md) (macOS iland
 Desktop dylib), [`swinging-bridge.md`](./swinging-bridge.md), [`vms-containers.md`](./vms-containers.md),
 [`wasm-package-manager.md`](./wasm-package-manager.md),
+[`linux-dmabuf-zero-copy.md`](./linux-dmabuf-zero-copy.md),
+[`agent-rules/wawona-ios-mode-b-channels.md`](./agent-rules/wawona-ios-mode-b-channels.md),
 [`repo.wawona.io`](https://github.com/Wawona/repo.wawona.io).
 
 Tracking: [#162](https://github.com/Wawona/Wawona/issues/162).
+
+---
+
+## iOS / iPadOS install channels (critical)
+
+Do **not** treat “Mode B” as a single binary. Three user-facing channels:
+
+| Channel | JIT | IOMobileFramebuffer / own-display | Desktop + LockScreen | Swinging Bridge |
+|---|---|---|---|---|
+| **App Store / TestFlight** | No | No | No | No |
+| **TrollStore (`ldid`)** | Yes | Yes | Yes (in-app own-display) | No |
+| **Sileo (`repo.wawona.io`)** | Yes | Yes | Yes (+ SpringBoard tweaks) | Yes + host APT |
+
+| Channel | How | VMs / containers / Wasm |
+|---|---|---|
+| **App Store / TestFlight** | ASC | **Jitless** QEMU-TCTI; Wasm **without** JIT |
+| **TrollStore sideload** | Website `.tipa` + TrollStore | **JIT** for VMs, containers, and Wasm |
+| **Sileo (`repo.wawona.io`)** | Jailbreak + Mode B IPA / `.deb` | **JIT** for VMs, containers, and Wasm |
+
+- Store IPA: never mention TrollStore, Sileo, jailbreak, JIT, or framebuffer SPI.
+- Website + `repo.wawona.io` document TrollStore and Sileo.
+- TrollStore Desktop is **IOMobileFramebuffer own-display** inside the Mode B
+  app (no ElleKit). Sileo adds SpringBoard injection (ElleKit on rootless),
+  host APT, and Swinging Bridge.
+- Never ship one ASC binary with a runtime “enable JIT / framebuffer” toggle.
+
+QEMU implementation:
+
+```text
+Mode A (store)           →  -accel tcg / TCTI (UTM SE). Interpreter ceiling.
+TrollStore or Sileo IPA  →  QEMU/UTM + JIT (Mode B scheme / WWN_MODE_B only).
+```
 
 ---
 
@@ -29,68 +63,89 @@ Design every iOS-family and Play path as Mode A first.
   (`wwn-zsh`, dispatch, libssh2).
 - **No JIT** on Apple mobile (no `MAP_JIT`, no Hypervisor for guests).
 - **VMs / containers (iOS family):** UTM-SE-class **jitless interpreter**
-  (`wwn-vms` QEMU-TCTI). Containers = OCI image pull (`wwn-oci`) +
-  **container-in-VM** on that jitless engine (`wwn-containers`). Same idea as
-  Apple Container on macOS, without JIT.
+  (`wwn-vms` QEMU-TCTI / `-accel tcg`). Containers = OCI image pull (`wwn-oci`) +
+  **container-in-VM** on that jitless engine (`wwn-containers`).
 - **Wasm packages:** `repo.wawona.io/wasm/` + Files drop + `wpm`. Bytecode as
-  **data** for Wawona Runtime (`wwn-wasm`). Not Mach-O, not `.deb`.
+  **data** for Wawona Runtime (`wwn-wasm`). **No Wasm JIT** in Mode A. Not Mach-O,
+  not `.deb`.
 - **iland:** `libiland_userland.a` present callback only (no Desktop `.dylib`).
-- tvOS / watchOS / visionOS: **no** VM/container machine kinds (policy).
+- Present: public Metal / `CAMetalLayer` only.
+- tvOS / watchOS: **no** VM/container machine kinds (policy). visionOS Mode A
+  uses the same jitless VM class as iOS when gated planned→available.
 
 ### Never in Mode A binaries
 
 - JIT-enabled UTM / QEMU TCG JIT on iOS family.
-- Sileo / Procursus APT client UI, jailbreak Desktop/LockScreen engage, “install
-  Mode B IPA” prompts.
+- IOMobileFramebuffer SPI, ElleKit, Substrate, jailbreak Desktop/LockScreen engage.
+- Sileo / Procursus APT client UI, “install Mode B IPA” prompts.
 - References to `repo.wawona.io/jailbreak/` or `.deb` tweak install from the app.
 - Unsigned native code download/`dlopen`.
 
 ---
 
-## Mode B. Jailbreak / SIP / root
+## Mode B. Jailbreak / TrollStore / SIP / root
 
-Mode B is **privileged host** access. Platforms:
+Mode B is **privileged host** access. On iOS/iPadOS there are **two** privileged
+install paths (see [install channels](#ios--ipados-install-channels-critical)):
 
 | Host | Mode B trigger |
 |------|----------------|
-| **iOS / iPadOS** | Jailbreak + packages from `repo.wawona.io` (Sileo) |
-| **macOS** | Desktop/LockScreen (iland Mode B): SIP fully disabled (`csrutil disable`) + `wawona-macos-desktop-host`. Other privileged Mode B paths (Swinging Bridge) are separate. |
+| **iOS / iPadOS (TrollStore)** | Sideloaded `.tipa` with `ldid` entitlements. JIT + IOMobileFramebuffer + Desktop/LockScreen (in-app). **No** Swinging Bridge / host APT / ElleKit |
+| **iOS / iPadOS (Sileo)** | Jailbreak + `repo.wawona.io` Mode B IPA / `.deb` + tweaks. Full Mode B including Swinging Bridge |
+| **macOS** | Desktop/LockScreen (iland Mode B): SIP fully disabled (`csrutil disable`) + `wawona-macos-desktop-host`. Other privileged Mode B paths (Swinging Bridge) are separate |
 | **Android** | Root / privileged paths outside Play requirements |
 
-### iOS / iPadOS Mode B (full)
+### iOS / iPadOS Mode B (TrollStore)
+
+| Capability | TrollStore Mode B |
+|------------|-------------------|
+| Desktop + LockScreen | Yes (IOMobileFramebuffer own-display greeter) |
+| Shell | Sideload / sandbox as designed for the Mode B IPA |
+| **VMs** | **JIT-enabled** UTM / QEMU |
+| **Containers** | **JIT-enabled** container-in-VM |
+| Wasm Runtime | Packages still from `/wasm/`; Mode B may **JIT-execute** Wasm |
+| Wawona Swinging Bridge | **No** (Sileo only) |
+| ElleKit / SpringBoard inject | **No** |
+
+Ship: `Wawona-{calver}-iOS-arm64.tipa` on GitHub Releases. Never Ship: beta / TestFlight.
+
+### iOS / iPadOS Mode B (full Sileo)
 
 On jailbreak, Wawona may use the host like NewTerm + UTM JIT + tweak stack:
 
-| Capability | Mode B |
+| Capability | Sileo Mode B (default) |
 |------------|--------|
-| Desktop + LockScreen replacement | Yes (`.deb` / tweak + Mode B IPA as designed) |
+| Desktop + LockScreen replacement | Yes (IOMFB and/or SpringBoard tweak + Mode B IPA) |
 | Shell | Real jailbreak shell / unsandboxed zsh. **not** limited to `wwn-zsh` hatch |
 | Host CLI | Jailbreak APT packages, NewTerm-class tools |
 | **VMs** | **JIT-enabled** UTM / QEMU |
-| **Containers** | **JIT-enabled** container-in-VM (same JIT engine) |
-| Wasm Runtime packages | Still available (`/wasm/`); plus host APT for native tweaks |
-| Wawona Swinging Bridge Mode B | UIKit→Wayland bridge tweak path |
+| **Containers** | **JIT-enabled** container-in-VM |
+| Wasm Runtime | Packages still from `/wasm/`; Mode B may **JIT-execute** Wasm |
+| Wawona Swinging Bridge Mode B | UIKit→Wayland bridge. **Enabled out of the box** |
 
-### Mode B IPA on `repo.wawona.io` (critical)
+Rootless (`.deb` `Architecture: iphoneos-arm64`, prefix `/var/jb`) and rootful
+(`Architecture: iphoneos-arm`, prefix `/`) are **separate builds**. Rootless
+SpringBoard tweaks depend on **ElleKit**. Never link ElleKit into store or
+TrollStore artifacts.
 
-`repo.wawona.io` must **automatically package and publish** a **Wawona iOS Mode B
-IPA** (Sileo-installable), distinct from the App Store IPA.
+### Mode B packages on `repo.wawona.io` (critical)
 
-When a user installs that Mode B build via Sileo they get:
+`repo.wawona.io` publishes under `/jailbreak/` (never `/wasm/`):
 
-1. Containers with **JIT** enablement  
-2. Virtual machines with **JIT** enablement  
-3. Access to **jailbroken iOS APT tooling** already on device (and repo `.deb`s)
+- Mode B IPA / app `.deb` (rootless and rootful)
+- ElleKit SpringBoard tweaks (Desktop / LockScreen / Swinging Bridge inject)
+- Test packages for the vphone `jb` guest lab
 
 App Store / TestFlight builds remain Mode A only and **must never** embed or
-switch into this IPA’s JIT backends.
+switch into these backends.
 
 ### macOS Mode B (summary)
 
 - iland Desktop/LockScreen: `libwayland-mac.dylib` in `.#wawona-macos-desktop-host`
   only. See [`iland-mode-a-b-desktop.md`](./iland-mode-a-b-desktop.md).
-- VMs: Virtualization.framework (already privileged vs MAS).
+- VMs: QEMU + HVF on macOS (`Hypervisor.framework`). See `wwn-vms`.
 - Containers: Apple Containerization (macOS-only engine).
+- macOS is **never** App Store feature-gated (`wawona-macos-no-appstore`).
 
 ### Android Mode B (summary)
 
@@ -105,29 +160,34 @@ switch into this IPA’s JIT backends.
 `wwn-vms`, `wwn-containers`, and Wawona Machines UI **must** compile and reason
 about Mode A and Mode B on iOS family at all times. Feature flags / product
 flavors select the engine; Mode B code is **absent** from store artifacts
-(compile-time `#if`, separate scheme, or stripped link), not merely hidden.
+(compile-time `#if`, separate scheme / `WWN_MODE_B`, or stripped link), not merely hidden.
 
 ```text
                  Machines: virtual_machine | container
                               │
               ┌───────────────┴───────────────┐
               ▼                               ▼
-     Mode A (store IPA)              Mode B (Sileo IPA)
-     UTM-SE / QEMU-TCTI              UTM / QEMU + JIT
-     jitless interpreter             JIT enablement
+     Mode A (store IPA)         Mode B IPA (TrollStore and/or Sileo)
+     QEMU-TCTI / TCG            QEMU / UTM + JIT
+     jitless interpreter        JIT (+ Wasm JIT) + IOMFB Desktop
               │                               │
               └──────────┬────────────────────┘
                          ▼
               shared: OCI pull (wwn-oci), profiles, waypipe/vsock GUI
+
+     Sileo jailbreak only (not TrollStore):
+              Swinging Bridge Mode B + host APT + ElleKit SpringBoard tweaks
 ```
 
-| Concern | Shared | Mode A only | Mode B only |
-|---------|--------|-------------|-------------|
-| OCI pull / CAS | Yes | - |. |
-| Machine profiles UI | Yes (no jailbreak copy in A) | Store strings | May mention JIT/Sileo on website; B IPA may expose JIT settings |
-| Guest boot engine | Interface | TCTI / UTM-SE | JIT UTM |
-| Container run | Interface | container-in-VM (jitless) | container-in-VM (JIT) |
-| Verification | - | `verify-*-mode-a` / no JIT symbols | CI for Mode B IPA + Sileo package |
+| Concern | Shared | Mode A only | Mode B (TrollStore / Sileo) | Sileo-only |
+|---------|--------|-------------|------------------------------|------------|
+| OCI pull / CAS | Yes | - | - | - |
+| Machine profiles UI | Yes (no jailbreak copy in A) | Store strings | JIT + Desktop settings OK in B IPA | SB UI |
+| Guest boot engine | Interface | TCTI / UTM-SE | JIT UTM/QEMU | - |
+| Container run | Interface | container-in-VM (jitless) | container-in-VM (JIT) | - |
+| Desktop present | - | Metal in-window | IOMobileFramebuffer | + ElleKit tweak |
+| Wasm execute | `/wasm/` packages | No JIT | Wasm JIT allowed | + host APT |
+| Verification | - | `verify-*-mode-a` / no Mode B symbols | Mode B `.tipa` CI | Sileo `.deb` + tweaks |
 
 Implementation plans: [`vms-mode-a-b.md`](./vms-mode-a-b.md),
 [`containers-mode-a-b.md`](./containers-mode-a-b.md) (also mirrored in
@@ -141,27 +201,30 @@ From [`wasm-package-manager.md`](./wasm-package-manager.md):
 
 **Wasm is not platform-native** (tradeoff vs a Mach-O port). The payoff is a
 **portable Wawona Runtime** plus dedicated **`wpm`**, with **full App Store /
-Play compliance** via WASI P1/P2. The Runtime itself has **no Mode B flavor**.
+Play compliance** via WASI P1/P2. Store (Mode A) Runtime never requires
+jailbreak. Mode B IPAs may still ship a **JIT-capable Wasm backend** when the
+JIT entitlement is present (TrollStore or Sileo). Packages remain `.wasm`
+bytecode on `/wasm/`; they are not `.deb`.
 
-| Channel | Mode A | Mode B |
-|---------|--------|--------|
-| `repo.wawona.io/wasm/` | Default registry for `wpm` / Packages GUI | Same Wasm registry still works |
-| `repo.wawona.io/jailbreak/` APT | **Forbidden** in app | Sileo + Mode B IPA; native `.deb` tweaks + host APT |
-| Files.app `.wasm` | Yes | Yes |
+| Channel | Mode A | Mode B (TrollStore / Sileo) |
+|---------|--------|------------------------------|
+| `repo.wawona.io/wasm/` | Default registry for `wpm` / Packages GUI | Same Wasm registry; **JIT execute** allowed in B IPA |
+| `repo.wawona.io/jailbreak/` APT | **Forbidden** in app | Sileo only; native `.deb` tweaks + host APT |
+| Files.app `.wasm` | Yes (no JIT) | Yes (JIT allowed in B) |
 | Debian `.deb` as Runtime packages | Never | Never (`.deb` ≠ Wasm) |
 
-Store builds: Wasm-only package client. Mode B: Wasm client **plus** jailbreak
+Store builds: Wasm-only package client. Mode B Sileo: Wasm client **plus** jailbreak
 APT ecosystem.
 
 ---
 
 ## Documentation firewall
 
-| Surface | Mode A detail | Mode B / jailbreak / JIT |
-|---------|---------------|---------------------------|
+| Surface | Mode A detail | Mode B / jailbreak / JIT / IOMFB |
+|---------|---------------|----------------------------------|
 | App Store IPA, TestFlight, Play | Full | **Zero** |
-| `wawona.io` user docs | Full | Allowed on dedicated pages |
-| `repo.wawona.io` | `/wasm/` | `/jailbreak/` + Mode B IPA packaging |
+| `wawona.io` user docs | Full | Allowed on dedicated pages (Download picker, Mode A/B) |
+| `repo.wawona.io` | `/wasm/` | `/jailbreak/` + Mode B IPA / `.deb` / tweaks |
 | Cursor / AGENTS rules | Both, labeled | Both, labeled |
 
 ---
@@ -170,10 +233,15 @@ APT ecosystem.
 
 1. **Never ship Mode B to the App Store / Play.** Separate artifact + CI gate.
 2. **Design A and B together** in `wwn-vms` / `wwn-containers` / Wawona. Shared
-   OCI and Machines model; divergent engines behind a capability gate.
-3. **iOS Mode A VMs/containers = interpreter (UTM-SE-class) only.**
-4. **iOS Mode B VMs/containers = JIT UTM-class**; packaged via Sileo Mode B IPA.
-5. **Wasm packages are Mode A-safe** and remain available under Mode B; they do
-   not replace jailbreak APT.
-6. **Do not conflate** iland Mode B (macOS dylib), Wawona Swinging Bridge Mode B, and iOS Mode B
-   IPA. Related privilege class, different artifacts.
+   OCI and Machines model; divergent engines behind a capability gate / `WWN_MODE_B`.
+3. **iOS Mode A VMs/containers = interpreter (QEMU-TCTI / UTM-SE) only.**
+4. **iOS Mode B VMs/containers/Wasm JIT** via TrollStore and/or Sileo Mode B IPA.
+5. **TrollStore** also enables IOMobileFramebuffer Desktop / LockScreen (in-app).
+   It does **not** enable Swinging Bridge or host APT.
+6. **Sileo full Mode B** also enables Swinging Bridge, host APT, and ElleKit
+   SpringBoard tweaks by default.
+7. **Wasm packages stay Mode A-safe data** (`/wasm/`); Mode B may JIT-execute.
+   They do not replace jailbreak APT.
+8. **Do not conflate** iland Mode B (macOS dylib), Wawona Swinging Bridge Mode B,
+   and iOS Mode B IPA / `.tipa` / `.deb`. Related privilege class, different artifacts.
+9. **Never link ElleKit** into store IPA or TrollStore `.tipa`.

--- a/docs/testing/vphone-jailbreak-lab.md
+++ b/docs/testing/vphone-jailbreak-lab.md
@@ -8,24 +8,113 @@ Upstream: https://github.com/Lakr233/vphone-cli (`jb` variant).
 - Apple Silicon, macOS 15+, Xcode + iOS SDK
 - Non-nested host
 - SIP Option A: `csrutil disable` + `amfi_get_out_of_my_way=1` (this Mac)
+- **`csrutil allow-research-guests enable`** (Recovery). Required for PV=3 DFU boot
 - Partial SIP + amfidont is not enough for Wawona Classic
 
 Do not flip Recovery/nvram from the agent. Operator owns that.
 
-## Usage
+## One command (preferred)
+
+From the Wawona checkout on Darwin aarch64:
 
 ```bash
-nix run .#vphone-cli -- vm create wawona-jb -V jb
-nix run .#vphone-cli -- vm launch wawona-jb
-# VNC :5901  SSH :22222 mobile/alpine
+nix run .#vphone-jb-lab
 ```
 
-IPSWs and `~/.vphone/` stay out of git (`VPHONE_ROOT`). First create downloads
-tens of GB. Prefer ≥128GB free disk.
+That script:
 
-## Proof loop
+1. Checks host gates (fails with Recovery instructions; never mutates nvram)
+2. Ensures `vphone-cli` + nix tools (`ldid-procursus`, libusb, aria2, sshpass)
+3. Creates `wawona-jb` if missing (`-V jb`, iOS 26.1 / cloudOS 26.1, non-interactive IPSW URLs)
+4. Resumes restore / CFW when a partial bundle already exists
+5. Launches the VM, waits for guest NAT SSH (`mobile@192.168.64.x:22222`)
+6. **Disables guest auto-lock** (`SBAutoLockTime=0` / `SBAutoLockDisabled`) so
+   SpringBoard never drops to the lock screen mid-automation
+7. Smokes Sileo + TrollStore Lite via `/var/log/vphone_jb_setup.log`
+8. Writes artifacts under `.agent-device/test-artifacts/dmabuf/vphone-jb/` (or `~/.vphone/artifacts/vphone-jb`)
+   plus `.agent-device/vphone-wawona-jb.json` for the Wawona `agent-device` fork
 
-1. Wait `/var/log/vphone_jb_setup.log` for Sileo + TrollStore
+Sock automation needs a **visible** (non-headless) VM window. Host `caffeinate`
+runs during launch; guest auto-lock is cleared in bootstrap (see `autolock.txt`).
+
+Flags:
+
+```bash
+nix run .#vphone-jb-lab -- --gate-only    # host checks only
+nix run .#vphone-jb-lab -- --smoke-only   # SSH smoke against a running guest
+```
+
+Env overrides: `VPHONE_ROOT`, `VPHONE_VM_NAME`, `VPHONE_DISK_GB`, `VPHONE_IOS_URL`,
+`VPHONE_CLOUDOS_URL`, `VPHONE_ARTIFACTS`, `WAWONA_ROOT`.
+
+Raw CLI (manual stages):
+
+```bash
+nix run .#vphone-cli -- vm create wawona-jb -V jb --disk-size 32 \
+  -i "$IPHONE_URL" -c "$CLOUDOS_URL"
+nix run .#vphone-cli -- vm launch wawona-jb -V jb
+```
+
+## Access
+
+After a green lab run:
+
+```bash
+# guest IP is also in the artifact guest-ip.txt / ready.txt
+ssh -p 22222 mobile@192.168.64.XX   # password alpine
+open vnc://192.168.64.XX:5901
+```
+
+SSH is on the **guest NAT address**, not `localhost` (VZ NAT). Prefer
+`guest-ip.txt` from the lab artifacts.
+
+## agent-device (Wawona fork)
+
+Pin is `nix-darwin` `modules/pkgs/_agent-device.nix` → local
+`~/Wawona/agent-device` (`0.18.3-wawona.1`). After pulling fork changes:
+
+```bash
+cd ~/Wawona/agent-device && nix shell nixpkgs#pnpm -c pnpm build
+# then refresh the home package / MCP wrapper
+nh switch   # or your usual darwin-rebuild / home-manager switch
+```
+
+Device selector (name works best; colon ids can confuse some shells):
+
+```bash
+export WAWONA_ROOT=~/Wawona/Wawona
+agent-device devices                    # expect: vphone wawona-jb … booted=true
+agent-device open --device "vphone wawona-jb" --session vphone
+agent-device screenshot --session vphone --out /tmp/vphone.png
+agent-device apps --session vphone
+agent-device install path/to/App.tipa --session vphone
+agent-device replay .agent-device/vphone-modeb-smoke.ad
+```
+
+Install path: SSH + `trollstorehelper install` (guest often has no `sftp-server`,
+so the fork pushes via `ssh … cat > file`). Does **not** require vphoned vsock.
+
+### Known guest limits (research iOS 26 jb)
+
+| Surface | Status |
+|---|---|
+| Host sock screenshot / tap / swipe / home | OK |
+| SSH apps / tipa install / uiopen | OK |
+| Snapshot refs | SSH icon-grid fallback when sock `ax` / vsock control is down |
+| vphoned control (`ipa_install` over vsock 1337) | Often **reset by peer** on this guest (no reliable `/dev/vsock`); use SSH tipa path |
+| `MAP_JIT` in Mode B tipa | Entitlements stamp OK; `mmap(MAP_JIT)` may still return `errno=22` on research guests even after `trollstorehelper enable-jit` |
+
+## Disk / tools notes
+
+- First create downloads ~12G+ IPSWs under `~/.vphone/ipsws`. Prefer ≥64G free
+  (128G+ for cold create).
+- CFW signing needs **ldid-procursus** (nix attribute). Plain `ldid` fails PKCS12.
+- DFU restore needs **libusb** on `DYLD_LIBRARY_PATH` (wired by the nix wrap).
+- `nix run .#vphone-cli` puts those on PATH automatically.
+
+## Proof loop (Mode B packages)
+
+1. Lab green (`ready.txt` + SSH smoke)
 2. Sileo: add `https://repo.wawona.io` (test `/jailbreak/test/` while on feature branch)
 3. Install rootless Wawona `.deb` + ElleKit tweak
 4. TrollStore: install `.tipa`

--- a/docs/testing/vphone-jailbreak-lab.md
+++ b/docs/testing/vphone-jailbreak-lab.md
@@ -1,0 +1,32 @@
+# vphone-cli Nix wrap (Darwin Apple Silicon)
+
+Jailbroken iOS 26 lab for Wawona Mode B proof. Not the Xcode Simulator.
+Upstream: https://github.com/Lakr233/vphone-cli (`jb` variant).
+
+## Host gates
+
+- Apple Silicon, macOS 15+, Xcode + iOS SDK
+- Non-nested host
+- SIP Option A: `csrutil disable` + `amfi_get_out_of_my_way=1` (this Mac)
+- Partial SIP + amfidont is not enough for Wawona Classic
+
+Do not flip Recovery/nvram from the agent. Operator owns that.
+
+## Usage
+
+```bash
+nix run .#vphone-cli -- vm create wawona-jb -V jb
+nix run .#vphone-cli -- vm launch wawona-jb
+# VNC :5901  SSH :22222 mobile/alpine
+```
+
+IPSWs and `~/.vphone/` stay out of git (`VPHONE_ROOT`). First create downloads
+tens of GB. Prefer ≥128GB free disk.
+
+## Proof loop
+
+1. Wait `/var/log/vphone_jb_setup.log` for Sileo + TrollStore
+2. Sileo: add `https://repo.wawona.io` (test `/jailbreak/test/` while on feature branch)
+3. Install rootless Wawona `.deb` + ElleKit tweak
+4. TrollStore: install `.tipa`
+5. Artifacts: `Wawona/.agent-device/test-artifacts/dmabuf/vphone-jb/`

--- a/docs/vms-containers.md
+++ b/docs/vms-containers.md
@@ -11,18 +11,21 @@ Desktop/LockScreen or Wawona Swinging Bridge.
 
 ## Mode A vs Mode B (iOS / iPadOS)
 
-| | **Mode A** (App Store IPA) | **Mode B** (Sileo Mode B IPA) |
-|---|---|---|
-| Engine | UTM-SE-class **jitless** interpreter | UTM/QEMU **with JIT** |
-| Containers | OCI pull + container-in-VM on jitless VM | Same OCI pull + **JIT** container-in-VM |
-| Ship | Store / TestFlight only | `repo.wawona.io` auto-packages Mode B IPA. **never** in App Store |
+| | **Mode A** (App Store IPA) | **TrollStore** (JIT IPA) | **Mode B** (Sileo Mode B IPA) |
+|---|---|---|---|
+| Engine | UTM-SE-class **jitless** interpreter | UTM/QEMU **with JIT** | UTM/QEMU **with JIT** |
+| Containers | OCI pull + container-in-VM on jitless VM | Same OCI + **JIT** container-in-VM | Same OCI + **JIT** container-in-VM |
+| Wasm | No JIT | Wasm JIT allowed | Wasm JIT allowed |
+| Desktop / LockScreen / Swinging Bridge | Forbidden | Not implied | **Yes** (out of the box) |
+| Ship | Store / TestFlight only | Website sideload | `repo.wawona.io` auto-packages Mode B IPA. **never** in App Store |
 
 Design both in `wwn-vms` / `wwn-containers` / Wawona at all times. Mode B code
-must be compile-time absent from store artifacts.
+must be compile-time absent from store artifacts. Channels:
+[`agent-rules/wawona-ios-mode-b-channels.md`](./agent-rules/wawona-ios-mode-b-channels.md).
 
-**Backends differ by OS:** macOS → Virtualization / Apple Containerization;
-iOS family → UTM-SE-class (A) or JIT UTM (B); Android → QEMU±KVM/proot. Do not
-share one engine across those hosts. **Note:** active work on macOS Apple
+**Backends differ by OS:** macOS → QEMU+HVF / Apple Containerization;
+iOS family → UTM-SE-class (A) or JIT UTM (B); Android → QEMU±KVM. Do not
+share one engine binary across those hosts. **Note:** active work on macOS Apple
 Container in `wwn-containers`. Leave that repo alone until it merges; VMs and
 Wasm packages proceed independently.
 
@@ -30,9 +33,9 @@ Wasm packages proceed independently.
 
 | Platform | Gate | Planned engine |
 |---|---|---|
-| macOS | planned | `Virtualization.framework` + Apple Containerization (not MAS for run) |
-| iOS / iPadOS | planned | **A:** jitless UTM-SE-class. **B:** JIT UTM via Sileo Mode B IPA |
-| Android | planned | QEMU ± KVM/AVF; Play = Mode A; root paths = Mode B |
+| macOS | planned | **QEMU + HVF** (`Hypervisor.framework`). Apple Containerization for containers |
+| iOS / iPadOS | planned | **A:** jitless QEMU-TCTI (UTM SE). **B:** JIT UTM via Sileo Mode B IPA |
+| Android | planned | **QEMU + Android HV** (`/dev/kvm`) with TCG+JIT fallback; Play = Mode A |
 | Linux | planned | Machine profiles via `wwn-vms` / `wwn-containers` |
 | tvOS / watchOS / visionOS | **forbidden** | Native + remote only |
 

--- a/docs/vms-mode-a-b.md
+++ b/docs/vms-mode-a-b.md
@@ -1,7 +1,8 @@
 # wwn-vms. Mode A / Mode B implementation plan
 
 Canonical product split: [Wawona `docs/mode-a-b.md`](https://github.com/Wawona/Wawona/blob/development/docs/mode-a-b.md).
-Mirror: keep this file in sync with `Wawona/docs/vms-mode-a-b.md`.
+iOS channels: [wawona-ios-mode-b-channels](https://github.com/Wawona/Wawona/blob/development/docs/agent-rules/wawona-ios-mode-b-channels.md).
+Mirror: keep this file in sync with `wwn-vms/docs/MODE-A-B.md`.
 
 ## Goal
 
@@ -10,10 +11,18 @@ Mode A vs Mode B on the iOS family:
 
 | Platform | Mode A engine | Mode B / privileged |
 |----------|---------------|---------------------|
-| **macOS** | `Virtualization.framework` (not MAS) | Same + SIP desktop-host paths |
-| **iOS / iPadOS** | UTM-SE-class **jitless** QEMU-TCTI | **JIT** UTM in Sileo Mode B IPA |
-| **Android** | QEMU TCG (± AVF/KVM when available) | Root/privileged paths as designed |
+| **macOS** | QEMU + HVF (`Hypervisor.framework`) | Same (macOS not App Store constrained) |
+| **iOS / iPadOS** | **jitless** QEMU-TCTI (`-accel tcg`, UTM SE) | **JIT** QEMU/UTM via **TrollStore** and/or **Sileo** Mode B IPA |
+| **Android** | QEMU + KVM when present, else TCG+JIT | Root/privileged paths as designed |
 | **Linux** | Host/QEMU profiles (TBD) | N/A |
+
+### iOS QEMU: interpreter vs JIT
+
+```text
+App Store / TestFlight  →  TCTI / TCG interpreter only. No MAP_JIT.
+TrollStore sideload     →  Mode B IPA flavor with JIT (VMs; containers share engine).
+Sileo (jailbreak)       →  Same JIT engine + Desktop/LockScreen/Swinging Bridge product.
+```
 
 Shared: Machines schema, guest artifacts, vsock + waypipe GUI, capability gates.
 **Do not** assume the iOS interpreter path on macOS/Android or vice versa.
@@ -29,13 +38,14 @@ or Wasm packages on it.
 - vsock + waypipe GUI path into Wawona
 - Capability gate API: `VmEngineKind = .interpreterJitless | .jitEnabled`
 - Unit tests against the interface, not a single binary
+- Rust helper: `wwn-vms` `crates/wwn-vms-engine` (`Tcti` vs `TcgJit`)
 
 ## Mode A implementation
 
 1. Link / embed only TCTI (UTM-SE model) sources from `dependencies/vms/utm/`
-   paths used for store builds.
+   paths used for store builds. Force `-accel tcg` (see `WWNMobileVmEngine`).
 2. CI: assert **no** JIT entitlements, no `MAP_JIT`, no Hypervisor on iOS store
-   schemes; symbol/string scan for jailbreak/JIT engage UI = fail.
+   schemes; symbol/string scan for jailbreak/JIT/TrollStore/Sileo engage UI = fail.
 3. Performance: document TCTI ceiling; tune guest size (existing README levers).
 4. Optional ODR/downloadable UTM-SE payload (see Wawona #33). Still jitless data.
 
@@ -43,29 +53,29 @@ or Wasm packages on it.
 
 1. Separate product flavor / scheme: `Wawona-iOS-ModeB` (name TBD) **not**
    submitted to ASC.
-2. Enable JIT UTM path (same family as jailbreak UTM / TrollStore JIT).
+2. Enable JIT UTM/QEMU path (TrollStore entitlement and/or jailbreak).
 3. `repo.wawona.io` CI: build Mode B IPA → Sileo package automatically.
-4. Mode B may use unsandboxed shell alongside VMs (product Mode B shell); VM
-   engine must not be the only Mode B feature.
-5. Website documents JIT; store IPA never mentions it.
+4. Website documents TrollStore (JIT) and Sileo (full Mode B). Store IPA never mentions either.
+5. Sileo product also ships Desktop / LockScreen / Swinging Bridge Mode B (not a VM-only IPA).
 
 ## Never
 
 - Ship Mode B engine inside App Store IPA “behind a toggle.”
 - Pretend jitless and JIT are the same binary with an env var.
-- Enable VM machine kind on tvOS/watchOS/visionOS (forbidden).
+- Enable VM machine kind on tvOS/watchOS (forbidden).
+- Document TrollStore as providing Desktop/LockScreen/Swinging Bridge by itself.
 
 ## Phases
 
 | Phase | Work |
 |-------|------|
 | 1 | Engine interface + Mode A TCTI stub→real boot on device |
-| 2 | Mode B JIT engine behind Mode-B-only target |
+| 2 | Mode B JIT engine behind Mode-B-only target (TrollStore + Sileo) |
 | 3 | repo.wawona.io auto Mode B IPA + Sileo metadata |
 | 4 | e2e: Mode A guest waypipe; Mode B JIT guest waypipe |
 
 ## Success
 
 - Store IPA boots a guest **without** JIT and passes App Store review notes.
-- Sileo Mode B IPA boots the same profile class **with** JIT.
+- TrollStore / Sileo Mode B IPA boots the same profile class **with** JIT.
 - Single Machines UI codepath; engine selected by build flavor / capability.

--- a/flake.nix
+++ b/flake.nix
@@ -744,6 +744,8 @@
           # wwn-igetty: Linux-shaped VTs + Doorman (Classic own-display).
           modeb-tty = wwn-igetty.packages.${system}.wwn-igetty;
           wwn-igetty = wwn-igetty.packages.${system}.wwn-igetty;
+          # Jailbroken iOS 26 lab (Virtualization.framework PCC). Apple Silicon only.
+          vphone-cli = pkgs.callPackage ./dependencies/tools/vphone-cli-app.nix { };
         };
 
         packages = commonPackages
@@ -1358,20 +1360,28 @@ APPLESCRIPT
             }
 
             kill_matching_wawona() {
-              # TERM leftover MacOS/Wawona processes so a stale flock lock
-              # cannot make the new compositor-host exit as "already running".
+              # TERM leftover Wawona processes so a stale flock lock cannot
+              # make the new compositor-host exit as "already running".
+              # Match full path AND bare process name (LaunchServices often
+              # shows only "Wawona" with no /Contents/MacOS/ prefix).
               ps -axo pid=,args= | while read -r pid args; do
                 case "$args" in
-                  *"/Contents/MacOS/Wawona"*)
-                    kill -TERM "$pid" >/dev/null 2>&1 || true
+                  *"/Contents/MacOS/Wawona"*|Wawona|Wawona\ *|WawonaMenuBar*|WawonaCompositor*)
+                    case "$args" in
+                      *Cursor*) ;;
+                      *) kill -TERM "$pid" >/dev/null 2>&1 || true ;;
+                    esac
                     ;;
                 esac
               done
               sleep 0.4
               ps -axo pid=,args= | while read -r pid args; do
                 case "$args" in
-                  *"/Contents/MacOS/Wawona"*)
-                    kill -KILL "$pid" >/dev/null 2>&1 || true
+                  *"/Contents/MacOS/Wawona"*|Wawona|Wawona\ *|WawonaMenuBar*|WawonaCompositor*)
+                    case "$args" in
+                      *Cursor*) ;;
+                      *) kill -KILL "$pid" >/dev/null 2>&1 || true ;;
+                    esac
                     ;;
                 esac
               done
@@ -2033,7 +2043,10 @@ APPLESCRIPT
         xcodegen-apple = { type = "app"; program = "${systemPackages.xcodegen-apple}/bin/xcodegen"; };
         xcodegen-novision = { type = "app"; program = "${systemPackages.xcodegen-novision}/bin/xcodegen"; };
         wawona-ios-provision = { type = "app"; program = "${systemPackages.wawona-ios-provision}/bin/provision-xcode"; };
-      } // (pkgs.lib.optionalAttrs (systemPackages ? graphics-validate-macos) {
+      } // (pkgs.lib.optionalAttrs (systemPackages ? vphone-cli) {
+        # Jailbroken iOS 26 lab (vphone-cli jb). See docs/testing/vphone-jailbreak-lab.md
+        vphone-cli = { type = "app"; program = "${systemPackages.vphone-cli}/bin/vphone-cli"; };
+      }) // (pkgs.lib.optionalAttrs (systemPackages ? graphics-validate-macos) {
         graphics-validate-macos = { type = "app"; program = "${systemPackages.graphics-validate-macos}/bin/graphics-validate-macos"; };
         # Fast graphics driver-sanity smoke, runnable as `nix run .#graphics-smoke`.
         graphics-smoke = { type = "app"; program = "${systemPackages.graphics-validate-macos}/bin/graphics-validate-macos"; };

--- a/scripts/package-ios-mode-b.sh
+++ b/scripts/package-ios-mode-b.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Package a Mode B iOS .app into TrollStore .tipa and/or Sileo .deb wrappers.
+# Never used by Ship: beta / TestFlight. See docs/agent-rules/wawona-release-assets.md
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $0 --app PATH.app --version CALVER --out DIR [--tipa] [--rootless-deb] [--rootful-deb] [--ldid PATH]
+EOF
+  exit 1
+}
+
+APP=""
+VERSION=""
+OUT="dist"
+DO_TIPA=0
+DO_ROOTLESS=0
+DO_ROOTFUL=0
+LDID="${LDID:-ldid}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app) APP="$2"; shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --tipa) DO_TIPA=1; shift ;;
+    --rootless-deb) DO_ROOTLESS=1; shift ;;
+    --rootful-deb) DO_ROOTFUL=1; shift ;;
+    --ldid) LDID="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "$APP" && -n "$VERSION" && -d "$APP" ]] || usage
+mkdir -p "$OUT"
+
+ENTITLEMENTS="$(mktemp)"
+cat >"$ENTITLEMENTS" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>get-task-allow</key><true/>
+  <key>platform-application</key><true/>
+  <key>com.apple.private.security.no-sandbox</key><true/>
+  <key>com.apple.private.security.container-required</key><false/>
+  <key>dynamic-codesigning</key><true/>
+  <key>com.apple.developer.kernel.increased-memory-limit</key><true/>
+</dict>
+</plist>
+PLIST
+
+BIN="$(/usr/bin/find "$APP" -maxdepth 2 -type f -perm +111 | head -1)"
+if [[ -z "$BIN" ]]; then
+  BIN="$APP/Wawona"
+fi
+
+if [[ "$DO_TIPA" -eq 1 ]]; then
+  if command -v "$LDID" >/dev/null 2>&1; then
+    "$LDID" -S"$ENTITLEMENTS" "$BIN" || true
+  else
+    echo "warning: ldid not found; packaging unsigned .tipa" >&2
+  fi
+  STAGE="$(mktemp -d)"
+  mkdir -p "$STAGE/Payload"
+  cp -R "$APP" "$STAGE/Payload/"
+  TIPA="$OUT/Wawona-${VERSION}-iOS-arm64.tipa"
+  (cd "$STAGE" && zip -qry "$OLDPWD/$TIPA" Payload)
+  rm -rf "$STAGE"
+  echo "wrote $TIPA"
+fi
+
+pack_deb() {
+  local scheme="$1" arch="$2" prefix="$3"
+  local stage control_dir data_root deb
+  stage="$(mktemp -d)"
+  control_dir="$stage/DEBIAN"
+  mkdir -p "$control_dir"
+  if [[ "$scheme" == "rootless" ]]; then
+    data_root="$stage${prefix}/Applications"
+  else
+    data_root="$stage/Applications"
+  fi
+  mkdir -p "$data_root"
+  cp -R "$APP" "$data_root/"
+  cat >"$control_dir/control" <<EOF
+Package: com.aspauldingcode.wawona
+Version: ${VERSION}
+Architecture: ${arch}
+Maintainer: Wawona Team <team@wawona.io>
+Description: Wawona Mode B (${scheme}) for jailbroken iOS
+Section: Applications
+Priority: optional
+Homepage: https://repo.wawona.io
+EOF
+  deb="$OUT/Wawona-${VERSION}-iOS-arm64-${scheme}.deb"
+  if command -v dpkg-deb >/dev/null 2>&1; then
+    dpkg-deb -Zxz -b "$stage" "$deb"
+  else
+    # Fallback: tar.gz named .deb for CI artifact wiring when dpkg-deb absent.
+    # Real Release ships must use dpkg-deb.
+    echo "warning: dpkg-deb missing; writing tar staging as ${deb}.tar.gz" >&2
+    tar -C "$stage" -czf "${deb}.tar.gz" .
+    echo "staged ${deb}.tar.gz (install dpkg-deb for real .deb)"
+    rm -rf "$stage"
+    return
+  fi
+  rm -rf "$stage"
+  echo "wrote $deb"
+}
+
+if [[ "$DO_ROOTLESS" -eq 1 ]]; then
+  pack_deb rootless iphoneos-arm64 /var/jb
+fi
+if [[ "$DO_ROOTFUL" -eq 1 ]]; then
+  pack_deb rootful iphoneos-arm /
+fi
+
+rm -f "$ENTITLEMENTS"

--- a/scripts/verify-ios-mode-b-absent.sh
+++ b/scripts/verify-ios-mode-b-absent.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Fail store-shaped IPA/AAB archives that contain Mode B / jailbreak markers.
+# Mode B .tipa jobs use the inverse check (must contain JIT/FB markers).
+set -euo pipefail
+
+ARCHIVE="${1:?usage: $0 path/to/Wawona.ipa|.aab|.app}"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+case "$ARCHIVE" in
+  *.ipa|*.tipa)
+    unzip -q "$ARCHIVE" -d "$TMP"
+    ROOT="$TMP/Payload"
+    ;;
+  *.app)
+    ROOT="$ARCHIVE"
+    ;;
+  *.aab|*.apk)
+    unzip -q "$ARCHIVE" -d "$TMP"
+    ROOT="$TMP"
+    ;;
+  *)
+    echo "unsupported archive: $ARCHIVE" >&2
+    exit 2
+    ;;
+esac
+
+PATTERNS='IOMobileFramebuffer|WWN_MODE_B|WWNIomfb|ellekit|TrollStore|repo\.wawona\.io/jailbreak|dynamic-codesigning|MAP_JIT'
+
+if [[ "$ARCHIVE" == *.tipa ]]; then
+  if ! grep -R -E -q "$PATTERNS" "$ROOT" 2>/dev/null; then
+    echo "FAIL: Mode B .tipa missing expected Mode B markers" >&2
+    exit 1
+  fi
+  echo "OK: Mode B markers present in $ARCHIVE"
+  exit 0
+fi
+
+if grep -R -E -q "$PATTERNS" "$ROOT" 2>/dev/null; then
+  echo "FAIL: store archive contains Mode B / jailbreak markers:" >&2
+  grep -R -E -n "$PATTERNS" "$ROOT" 2>/dev/null | head -40 >&2
+  exit 1
+fi
+echo "OK: no Mode B markers in $ARCHIVE"

--- a/src/core/wayland/ext/linux_dmabuf.rs
+++ b/src/core/wayland/ext/linux_dmabuf.rs
@@ -1,28 +1,14 @@
-//! Linux DMABuf Protocol Implementation
+//! Linux DMABuf Protocol Implementation (`zwp_linux_dmabuf_v1`)
 //!
-//! This module provides the linux-dmabuf protocol implementation for Wawona.
-//! 
-//! # How It Works
+//! OS import switch (see `docs/linux-dmabuf-zero-copy.md`):
+//! - Apple (except watchOS): high-bit modifier = IOSurface id (`NativeBufferData`)
+//! - Android: same high-bit = AHardwareBuffer id (`NativeBufferData`)
+//! - Linux: LINEAR + real modifiers; store as `BufferType::DmaBuf`
+//! - watchOS: global is **not** registered
 //!
-//! On macOS, DMABUF handling is delegated to waypipe which uses kosmickrisp
-//! (Vulkan-on-Metal driver) to import/export GPU buffers. kosmickrisp supports
-//! `VK_EXT_external_memory_dma_buf` for cross-process buffer sharing.
-//!
-//! The Wawona compositor advertises linux-dmabuf formats so that:
-//! - waypipe can intercept and handle DMABUF requests via Vulkan
-//! - Clients know that DMABUF is available (handled by waypipe)
-//!
-//! # Nested Compositors (Weston, etc.)
-//!
-//! Nested compositors like Weston can run through waypipe with full GPU
-//! acceleration. waypipe handles the DMABUF protocol via Vulkan/kosmickrisp.
-//!
-//! # Buffer Flow
-//!
-//! 1. Remote client creates DMABUF buffer
-//! 2. waypipe-server intercepts and sends buffer data to waypipe-client
-//! 3. waypipe-client uses kosmickrisp Vulkan to import the buffer
-//! 4. Buffer is rendered via Metal on macOS
+//! Never advertise `DRM_FORMAT_MOD_LINEAR` on Apple or Android.
+//! Structured logs use target `wwn.dmabuf` with fields op/os/sink/modifier/
+//! backing_id/format/copy/client.
 
 use wayland_server::{
     Dispatch, DisplayHandle, GlobalDispatch, Resource,
@@ -36,12 +22,17 @@ use std::os::fd::RawFd;
 use crate::core::state::CompositorState;
 use std::collections::HashMap;
 
-/// Data stored with DMA-BUF buffer params
+/// High bit set: IOSurface (Apple) or AHB (Android) id in low 63 bits.
+pub const PLATFORM_NATIVE_MODIFIER: u64 = 0x8000_0000_0000_0000;
+pub const DRM_FORMAT_ARGB8888: u32 = 0x34325241; // 'AR24'
+pub const DRM_FORMAT_XRGB8888: u32 = 0x34325258; // 'XR24'
+pub const DRM_FORMAT_MOD_LINEAR: u64 = 0;
+
 #[derive(Debug, Clone, Default)]
 pub struct DmabufBufferParamsData {
     pub width: u32,
     pub height: u32,
-    pub format: u32, // DRM fourcc format
+    pub format: u32,
     pub flags: u32,
     pub fds: Vec<i32>,
     pub offsets: Vec<u32>,
@@ -60,8 +51,6 @@ pub struct LinuxDmabufState {
     pub pending_params: HashMap<(wayland_server::backend::ClientId, u32), DmabufBufferParamsData>,
 }
 
-
-// CoreFoundation/IOSurface bindings (Apple platforms only)
 #[cfg(target_vendor = "apple")]
 #[link(name = "IOSurface", kind = "framework")]
 extern "C" {}
@@ -93,6 +82,149 @@ fn close_raw_fds(fds: &[RawFd]) {
     }
 }
 
+fn is_platform_native_modifier(modifier: u64) -> bool {
+    (modifier & PLATFORM_NATIVE_MODIFIER) != 0
+}
+
+fn native_backing_id(modifier: u64) -> u64 {
+    modifier & 0x7FFF_FFFF_FFFF_FFFF
+}
+
+/// Host label for structured `wwn.dmabuf` logs.
+fn dmabuf_os_label() -> &'static str {
+    #[cfg(target_os = "android")]
+    {
+        "android"
+    }
+    #[cfg(all(target_vendor = "apple", not(target_os = "android")))]
+    {
+        "apple"
+    }
+    #[cfg(all(not(target_vendor = "apple"), not(target_os = "android")))]
+    {
+        "linux"
+    }
+}
+
+fn dmabuf_sink_label() -> &'static str {
+    #[cfg(target_os = "android")]
+    {
+        "ahb_surface"
+    }
+    #[cfg(all(target_vendor = "apple", not(target_os = "android")))]
+    {
+        "apple_metal"
+    }
+    #[cfg(all(not(target_vendor = "apple"), not(target_os = "android")))]
+    {
+        "linux_gbm"
+    }
+}
+
+fn advertise_formats(dmabuf: &zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1) {
+    #[cfg(any(target_vendor = "apple", target_os = "android"))]
+    {
+        let mod_hi = ((PLATFORM_NATIVE_MODIFIER >> 32) & 0xffff_ffff) as u32;
+        let mod_lo = (PLATFORM_NATIVE_MODIFIER & 0xffff_ffff) as u32;
+        if dmabuf.version() >= 3 {
+            dmabuf.modifier(DRM_FORMAT_ARGB8888, mod_hi, mod_lo);
+            dmabuf.modifier(DRM_FORMAT_XRGB8888, mod_hi, mod_lo);
+        } else {
+            dmabuf.format(DRM_FORMAT_ARGB8888);
+            dmabuf.format(DRM_FORMAT_XRGB8888);
+        }
+        tracing::info!(
+            target: "wwn.dmabuf",
+            op = "modifier_ad",
+            os = dmabuf_os_label(),
+            sink = dmabuf_sink_label(),
+            modifier = format!("0x{PLATFORM_NATIVE_MODIFIER:016x}"),
+            copy = "zero",
+            "advertised platform-native modifiers for ARGB8888/XRGB8888"
+        );
+    }
+    #[cfg(all(not(target_vendor = "apple"), not(target_os = "android")))]
+    {
+        let mod_hi = ((DRM_FORMAT_MOD_LINEAR >> 32) & 0xffff_ffff) as u32;
+        let mod_lo = (DRM_FORMAT_MOD_LINEAR & 0xffff_ffff) as u32;
+        if dmabuf.version() >= 3 {
+            dmabuf.modifier(DRM_FORMAT_ARGB8888, mod_hi, mod_lo);
+            dmabuf.modifier(DRM_FORMAT_XRGB8888, mod_hi, mod_lo);
+        } else {
+            dmabuf.format(DRM_FORMAT_ARGB8888);
+            dmabuf.format(DRM_FORMAT_XRGB8888);
+        }
+        tracing::info!(
+            target: "wwn.dmabuf",
+            op = "modifier_ad",
+            os = "linux",
+            sink = "linux_gbm",
+            modifier = format!("0x{DRM_FORMAT_MOD_LINEAR:016x}"),
+            copy = "zero",
+            "advertised LINEAR modifiers for ARGB8888/XRGB8888"
+        );
+    }
+}
+
+fn send_dmabuf_feedback(
+    feedback: &zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1,
+) {
+    use std::io::Write;
+    use std::os::fd::AsFd;
+
+    const FORMATS: [u32; 2] = [DRM_FORMAT_ARGB8888, DRM_FORMAT_XRGB8888];
+
+    #[cfg(any(target_vendor = "apple", target_os = "android"))]
+    let table_modifier = PLATFORM_NATIVE_MODIFIER;
+    #[cfg(all(not(target_vendor = "apple"), not(target_os = "android")))]
+    let table_modifier = DRM_FORMAT_MOD_LINEAR;
+
+    match tempfile::tempfile() {
+        Ok(mut file) => {
+            for fmt in FORMATS {
+                let mut rec = [0u8; 16];
+                rec[0..4].copy_from_slice(&fmt.to_le_bytes());
+                rec[8..16].copy_from_slice(&table_modifier.to_le_bytes());
+                if file.write_all(&rec).is_err() {
+                    tracing::warn!(target: "wwn.dmabuf", op = "feedback", "failed to write format table");
+                    feedback.format_table(file.as_fd(), 0);
+                    feedback.main_device(Vec::new());
+                    feedback.done();
+                    return;
+                }
+            }
+            let _ = file.flush();
+            let table_size = (FORMATS.len() * 16) as u32;
+            feedback.format_table(file.as_fd(), table_size);
+
+            let dummy_dev = vec![0u8; 8];
+            feedback.main_device(dummy_dev.clone());
+            feedback.tranche_target_device(dummy_dev);
+            let mut indices = Vec::with_capacity(FORMATS.len() * 2);
+            for i in 0u16..(FORMATS.len() as u16) {
+                indices.extend_from_slice(&i.to_le_bytes());
+            }
+            feedback.tranche_formats(indices);
+            feedback.tranche_done();
+            feedback.done();
+            tracing::info!(
+                target: "wwn.dmabuf",
+                op = "feedback",
+                os = dmabuf_os_label(),
+                sink = dmabuf_sink_label(),
+                modifier = format!("0x{table_modifier:016x}"),
+                copy = "zero",
+                "dmabuf feedback done"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(target: "wwn.dmabuf", op = "feedback", error = %e, "failed to create format table");
+            feedback.main_device(Vec::new());
+            feedback.done();
+        }
+    }
+}
+
 impl GlobalDispatch<zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, ()> for CompositorState {
     fn bind(
         _state: &mut Self,
@@ -103,25 +235,15 @@ impl GlobalDispatch<zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, ()> for CompositorSta
         data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
         let dmabuf = data_init.init(resource, ());
-
-        // Advertise the IOSurface-modifier convention (#86 / wwn-iland + waypipe).
-        // High bit set = IOSurface id in low 63 bits. Do NOT advertise LINEAR
-        // (raw dmabuf). That path is unsupported and caused client failures.
-        const DRM_FORMAT_ARGB8888: u32 = 0x34325241; // 'AR24'
-        const DRM_FORMAT_XRGB8888: u32 = 0x34325258; // 'XR24'
-        const IOSURFACE_MODIFIER: u64 = 0x8000_0000_0000_0000;
-        let mod_hi = ((IOSURFACE_MODIFIER >> 32) & 0xffff_ffff) as u32;
-        let mod_lo = (IOSURFACE_MODIFIER & 0xffff_ffff) as u32;
-        if dmabuf.version() >= 3 {
-            dmabuf.modifier(DRM_FORMAT_ARGB8888, mod_hi, mod_lo);
-            dmabuf.modifier(DRM_FORMAT_XRGB8888, mod_hi, mod_lo);
-        } else {
-            dmabuf.format(DRM_FORMAT_ARGB8888);
-            dmabuf.format(DRM_FORMAT_XRGB8888);
-        }
         tracing::info!(
-            "linux-dmabuf bound: advertised IOSurface modifiers for ARGB8888/XRGB8888"
+            target: "wwn.dmabuf",
+            op = "bind",
+            os = dmabuf_os_label(),
+            sink = dmabuf_sink_label(),
+            version = dmabuf.version(),
+            "linux-dmabuf bound"
         );
+        advertise_formats(&dmabuf);
     }
 }
 
@@ -144,15 +266,16 @@ impl Dispatch<zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, ()> for CompositorState {
                     flags: 0,
                     planes: Vec::new(),
                 };
-                let _: zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1 = data_init.init(params_id, params);
+                let _: zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1 =
+                    data_init.init(params_id, params);
             }
             zwp_linux_dmabuf_v1::Request::GetDefaultFeedback { id } => {
                 let feedback = data_init.init(id, ());
-                send_iosurface_dmabuf_feedback(&feedback);
+                send_dmabuf_feedback(&feedback);
             }
             zwp_linux_dmabuf_v1::Request::GetSurfaceFeedback { id, surface: _ } => {
                 let feedback = data_init.init(id, ());
-                send_iosurface_dmabuf_feedback(&feedback);
+                send_dmabuf_feedback(&feedback);
             }
             zwp_linux_dmabuf_v1::Request::Destroy => {}
             _ => {}
@@ -161,59 +284,6 @@ impl Dispatch<zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, ()> for CompositorState {
 }
 
 use wayland_protocols::wp::linux_dmabuf::zv1::server::zwp_linux_dmabuf_feedback_v1;
-
-/// Advertise IOSurface-modifier dmabuf formats (v4 feedback). Clients waiting
-/// on `done` proceed immediately. Do not advertise LINEAR (raw dmabuf): that
-/// path is unsupported and caused client failures.
-fn send_iosurface_dmabuf_feedback(
-    feedback: &zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1,
-) {
-    use std::io::Write;
-    use std::os::fd::AsFd;
-
-    const DRM_FORMAT_ARGB8888: u32 = 0x34325241;
-    const DRM_FORMAT_XRGB8888: u32 = 0x34325258;
-    const IOSURFACE_MODIFIER: u64 = 0x8000_0000_0000_0000;
-    const FORMATS: [u32; 2] = [DRM_FORMAT_ARGB8888, DRM_FORMAT_XRGB8888];
-
-    match tempfile::tempfile() {
-        Ok(mut file) => {
-            for fmt in FORMATS {
-                let mut rec = [0u8; 16];
-                rec[0..4].copy_from_slice(&fmt.to_le_bytes());
-                rec[8..16].copy_from_slice(&IOSURFACE_MODIFIER.to_le_bytes());
-                if file.write_all(&rec).is_err() {
-                    tracing::warn!("linux-dmabuf: failed to write format table");
-                    feedback.format_table(file.as_fd(), 0);
-                    feedback.main_device(Vec::new());
-                    feedback.done();
-                    return;
-                }
-            }
-            let _ = file.flush();
-            let table_size = (FORMATS.len() * 16) as u32;
-            feedback.format_table(file.as_fd(), table_size);
-
-            // No DRM render node on Wawona hosts. 8 zero bytes so the tranche
-            // still names a device; clients that require a real node fall back.
-            let dummy_dev = vec![0u8; 8];
-            feedback.main_device(dummy_dev.clone());
-            feedback.tranche_target_device(dummy_dev);
-            let mut indices = Vec::with_capacity(FORMATS.len() * 2);
-            for i in 0u16..(FORMATS.len() as u16) {
-                indices.extend_from_slice(&i.to_le_bytes());
-            }
-            feedback.tranche_formats(indices);
-            feedback.tranche_done();
-            feedback.done();
-        }
-        Err(e) => {
-            tracing::warn!("linux-dmabuf: failed to create format table: {}", e);
-            feedback.main_device(Vec::new());
-            feedback.done();
-        }
-    }
-}
 
 impl Dispatch<zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1, ()> for CompositorState {
     fn request(
@@ -232,6 +302,136 @@ impl Dispatch<zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1, ()> for Co
     }
 }
 
+/// Import path after planes are collected. Returns true if a wl_buffer was created.
+fn import_dmabuf_planes(
+    state: &mut CompositorState,
+    client: &wayland_server::Client,
+    dhandle: &DisplayHandle,
+    p: DmabufBufferParamsData,
+    width: i32,
+    height: i32,
+    format: u32,
+    immed: Option<(
+        wayland_server::New<wayland_server::protocol::wl_buffer::WlBuffer>,
+        &mut wayland_server::DataInit<'_, CompositorState>,
+    )>,
+    created_out: Option<&zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1>,
+) -> bool {
+    use crate::core::surface::buffer::{Buffer, BufferType, NativeBufferData};
+    #[cfg(all(not(target_vendor = "apple"), not(target_os = "android")))]
+    use crate::core::surface::buffer::DmaBufData;
+    use wayland_server::protocol::wl_buffer::WlBuffer;
+
+    let modifier = p.modifiers.first().copied().unwrap_or(0);
+    let client_id = client.id();
+
+    #[cfg(any(target_vendor = "apple", target_os = "android"))]
+    {
+        if !is_platform_native_modifier(modifier) {
+            tracing::warn!(
+                target: "wwn.dmabuf",
+                op = "create",
+                os = dmabuf_os_label(),
+                sink = dmabuf_sink_label(),
+                modifier = format!("0x{modifier:016x}"),
+                format,
+                copy = "cpu",
+                "rejecting non-native modifier on this OS"
+            );
+            close_raw_fds(&p.fds);
+            return false;
+        }
+        let backing_id = native_backing_id(modifier);
+        tracing::info!(
+            target: "wwn.dmabuf",
+            op = if immed.is_some() { "create_immed" } else { "create" },
+            os = dmabuf_os_label(),
+            sink = dmabuf_sink_label(),
+            modifier = format!("0x{modifier:016x}"),
+            backing_id,
+            format,
+            copy = "zero",
+            "importing platform-native buffer"
+        );
+
+        let buffer_resource = if let Some((buffer_id, data_init)) = immed {
+            data_init.init(buffer_id, ())
+        } else {
+            let buffer_resource = client
+                .create_resource::<WlBuffer, (), CompositorState>(dhandle, 1, ())
+                .expect("Failed to create wl_buffer resource");
+            if let Some(params) = created_out {
+                params.created(&buffer_resource);
+            }
+            buffer_resource
+        };
+        let internal_id = buffer_resource.id().protocol_id();
+        let buffer = Buffer::new(
+            internal_id,
+            BufferType::Native(NativeBufferData {
+                id: backing_id,
+                width,
+                height,
+                format,
+            }),
+            Some(buffer_resource),
+        );
+        state
+            .buffers
+            .insert((client_id, internal_id), std::sync::Arc::new(std::sync::RwLock::new(buffer)));
+        close_raw_fds(&p.fds);
+        return true;
+    }
+
+    #[cfg(all(not(target_vendor = "apple"), not(target_os = "android")))]
+    {
+        // Linux: accept LINEAR and any modifier; keep fds in DmaBufData for GBM present.
+        tracing::info!(
+            target: "wwn.dmabuf",
+            op = if immed.is_some() { "create_immed" } else { "create" },
+            os = "linux",
+            sink = "linux_gbm",
+            modifier = format!("0x{modifier:016x}"),
+            backing_id = p.fds.first().copied().unwrap_or(-1),
+            format,
+            copy = "zero",
+            "importing linux dmabuf planes"
+        );
+
+        let buffer_resource = if let Some((buffer_id, data_init)) = immed {
+            data_init.init(buffer_id, ())
+        } else {
+            let buffer_resource = client
+                .create_resource::<WlBuffer, (), CompositorState>(dhandle, 1, ())
+                .expect("Failed to create wl_buffer resource");
+            if let Some(params) = created_out {
+                params.created(&buffer_resource);
+            }
+            buffer_resource
+        };
+        let internal_id = buffer_resource.id().protocol_id();
+        let buffer = Buffer::new(
+            internal_id,
+            BufferType::DmaBuf(DmaBufData {
+                width: width as u32,
+                height: height as u32,
+                format,
+                modifier,
+                fds: p.fds.clone(),
+                offsets: p.offsets.clone(),
+                strides: p.strides.clone(),
+            }),
+            Some(buffer_resource),
+        );
+        state
+            .buffers
+            .insert((client_id, internal_id), std::sync::Arc::new(std::sync::RwLock::new(buffer)));
+        // fds are owned by DmaBufData now; do not close.
+        let _ = p;
+        return true;
+    }
+}
+
 impl Dispatch<zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1, BufferParams> for CompositorState {
     fn request(
         state: &mut Self,
@@ -243,18 +443,38 @@ impl Dispatch<zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1, BufferParams> 
         data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
         match request {
-            zwp_linux_buffer_params_v1::Request::Add { fd, plane_idx, offset, stride, modifier_hi, modifier_lo } => {
+            zwp_linux_buffer_params_v1::Request::Add {
+                fd,
+                plane_idx,
+                offset,
+                stride,
+                modifier_hi,
+                modifier_lo,
+            } => {
                 let modifier = ((modifier_hi as u64) << 32) | (modifier_lo as u64);
-                tracing::debug!("linux-dmabuf: Received plane {} (modifier=0x{:016x})", plane_idx, modifier);
-                
+                tracing::debug!(
+                    target: "wwn.dmabuf",
+                    op = "add_plane",
+                    plane_idx,
+                    modifier = format!("0x{modifier:016x}"),
+                    stride,
+                    "received plane"
+                );
+
                 let params_id = resource.id().protocol_id();
                 let client_id = _client.id();
-                let p = state.ext.linux_dmabuf.pending_params.entry((client_id, params_id)).or_default();
-                
-                // Store FD by converting to raw (we own it now)
+                let p = state
+                    .ext
+                    .linux_dmabuf
+                    .pending_params
+                    .entry((client_id, params_id))
+                    .or_default();
+
                 let raw_fd = fd.into_raw_fd();
                 if stride == 0 {
-                    unsafe { libc::close(raw_fd); }
+                    unsafe {
+                        libc::close(raw_fd);
+                    }
                     resource.failed();
                     return;
                 }
@@ -263,102 +483,75 @@ impl Dispatch<zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1, BufferParams> 
                 p.strides.push(stride);
                 p.modifiers.push(modifier);
             }
-            zwp_linux_buffer_params_v1::Request::Create { width, height, format, flags: _ } => {
+            zwp_linux_buffer_params_v1::Request::Create {
+                width,
+                height,
+                format,
+                flags: _,
+            } => {
                 let params_id = resource.id().protocol_id();
                 let client_id = _client.id();
-                if let Some(p) = state.ext.linux_dmabuf.pending_params.remove(&(client_id.clone(), params_id)) {
+                if let Some(p) = state
+                    .ext
+                    .linux_dmabuf
+                    .pending_params
+                    .remove(&(client_id, params_id))
+                {
                     if p.fds.is_empty() || width <= 0 || height <= 0 {
                         close_raw_fds(&p.fds);
                         resource.failed();
                         return;
                     }
-                    let modifier = p.modifiers.first().copied().unwrap_or(0);
-
-                    let is_iosurface = (modifier & 0x8000_0000_0000_0000) != 0;
-                    if is_iosurface {
-                        let surface_id = (modifier & 0x7FFF_FFFF_FFFF_FFFF) as u32;
-                        tracing::info!("linux-dmabuf: Importing IOSurface ID {} (Asynchronous) from modifier 0x{:016x}", surface_id, modifier);
-
-                        use crate::core::surface::buffer::{Buffer, BufferType, NativeBufferData};
-                        use wayland_server::Resource;
-                        use wayland_server::protocol::wl_buffer::WlBuffer;
-                        
-                        // Manually create the wl_buffer resource since 'created' event creates it
-                        let buffer_resource = _client.create_resource::<WlBuffer, (), CompositorState>(
-                            _dhandle,
-                            1,
-                            (),
-                        ).expect("Failed to create wl_buffer resource");
-
-                        // Emit 'created' event with the new resource
-                        resource.created(&buffer_resource);
-                        
-                        let internal_id = buffer_resource.id().protocol_id();
-
-                        let buffer = Buffer::new(
-                            internal_id,
-                            BufferType::Native(NativeBufferData {
-                                id: surface_id as u64,
-                                width,
-                                height,
-                                format,
-                            }),
-                            Some(buffer_resource.clone())
-                        );
-
-                        state.buffers.insert((client_id, internal_id), std::sync::Arc::new(std::sync::RwLock::new(buffer)));
-                        close_raw_fds(&p.fds);
-                    } else {
-                        close_raw_fds(&p.fds);
+                    if !import_dmabuf_planes(
+                        state,
+                        _client,
+                        _dhandle,
+                        p,
+                        width,
+                        height,
+                        format,
+                        None,
+                        Some(resource),
+                    ) {
                         resource.failed();
                     }
                 } else {
                     resource.failed();
                 }
             }
-            zwp_linux_buffer_params_v1::Request::CreateImmed { buffer_id, width, height, format, flags: _ } => {
-               
+            zwp_linux_buffer_params_v1::Request::CreateImmed {
+                buffer_id,
+                width,
+                height,
+                format,
+                flags: _,
+            } => {
                 let params_id = resource.id().protocol_id();
                 let client_id = _client.id();
-                if let Some(p) = state.ext.linux_dmabuf.pending_params.remove(&(client_id.clone(), params_id)) {
-                     if p.fds.is_empty() || width <= 0 || height <= 0 {
-                         close_raw_fds(&p.fds);
-                         resource.failed();
-                         return;
-                     }
-                     let modifier = p.modifiers.first().copied().unwrap_or(0);
-
-                     let is_iosurface = (modifier & 0x8000_0000_0000_0000) != 0;
-                     if is_iosurface {
-                         let surface_id = (modifier & 0x7FFF_FFFF_FFFF_FFFF) as u32;
-                         tracing::info!("linux-dmabuf: Importing IOSurface ID {} (Immediate) from modifier 0x{:016x}", surface_id, modifier);
-                         
-                         // Create the buffer stored in CompositorState
-                         use crate::core::surface::buffer::{Buffer, BufferType, NativeBufferData};
-                         use wayland_server::Resource;
-                         
-                         let buffer_resource = data_init.init(buffer_id, ());
-                         let internal_id = buffer_resource.id().protocol_id();
-                         
-                         let buffer = Buffer::new(
-                             internal_id,
-                             BufferType::Native(NativeBufferData {
-                                 id: surface_id as u64,
-                                 width,
-                                 height,
-                                 format,
-                             }),
-                             Some(buffer_resource.clone())
-                         );
-                         
-                         state.buffers.insert((client_id, internal_id), std::sync::Arc::new(std::sync::RwLock::new(buffer)));
-                         close_raw_fds(&p.fds);
-                         
-                         // Note: We don't send 'created' event for CreateImmed.
-                     } else {
-                         close_raw_fds(&p.fds);
-                         resource.failed();
-                     }
+                if let Some(p) = state
+                    .ext
+                    .linux_dmabuf
+                    .pending_params
+                    .remove(&(client_id, params_id))
+                {
+                    if p.fds.is_empty() || width <= 0 || height <= 0 {
+                        close_raw_fds(&p.fds);
+                        resource.failed();
+                        return;
+                    }
+                    if !import_dmabuf_planes(
+                        state,
+                        _client,
+                        _dhandle,
+                        p,
+                        width,
+                        height,
+                        format,
+                        Some((buffer_id, data_init)),
+                        None,
+                    ) {
+                        resource.failed();
+                    }
                 } else {
                     resource.failed();
                 }
@@ -369,8 +562,31 @@ impl Dispatch<zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1, BufferParams> 
     }
 }
 
+/// Whether this host should advertise `zwp_linux_dmabuf_v1`.
+/// watchOS uses SpriteKit of `wl_shm` only; nested niri checks this via absence.
+pub fn host_offers_linux_dmabuf() -> bool {
+    #[cfg(target_os = "watchos")]
+    {
+        false
+    }
+    #[cfg(not(target_os = "watchos"))]
+    {
+        true
+    }
+}
 
-/// Register zwp_linux_dmabuf_v1 global
-pub fn register_linux_dmabuf(display: &DisplayHandle) -> wayland_server::backend::GlobalId {
-    display.create_global::<CompositorState, zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, ()>(4, ())
+/// Register zwp_linux_dmabuf_v1 global (newest practical stable: v4).
+/// No-op on watchOS.
+pub fn register_linux_dmabuf(display: &DisplayHandle) -> Option<wayland_server::backend::GlobalId> {
+    if !host_offers_linux_dmabuf() {
+        tracing::info!(
+            target: "wwn.dmabuf",
+            op = "bind",
+            os = "watchos",
+            sink = "watch_spritekit",
+            "skipping linux-dmabuf global on watchOS"
+        );
+        return None;
+    }
+    Some(display.create_global::<CompositorState, zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, ()>(4, ()))
 }

--- a/src/core/wayland/ext/linux_drm_syncobj.rs
+++ b/src/core/wayland/ext/linux_drm_syncobj.rs
@@ -1,6 +1,17 @@
-//! Linux DRM Syncobj protocol implementation.
+//! linux-drm-syncobj-v1: timeline fences for GPU clients.
+//!
+//! Registers the global and accepts surface attach of acquire/release
+//! timelines. Full DRM syncobj wait/signal on Linux GBM present is follow-on;
+//! Apple/Android treat attach as acknowledged (IOSurface/AHB already ordered
+//! by Metal/Vulkan). See docs/linux-dmabuf-zero-copy.md.
 
 use std::collections::HashMap;
+
+use wayland_server::{
+    Dispatch, DisplayHandle, GlobalDispatch, Resource,
+};
+
+use crate::core::state::CompositorState;
 
 /// State for the linux-drm-syncobj-v1 protocol
 #[derive(Debug, Default)]
@@ -13,10 +24,199 @@ pub struct SyncObjState {
     pub syncobj_timelines: HashMap<u32, Option<i32>>,
 }
 
-use wayland_server::DisplayHandle;
+#[cfg(feature = "desktop-protocols")]
+mod proto {
+    use super::*;
+    use wayland_protocols::wp::linux_drm_syncobj::v1::server::{
+        wp_linux_drm_syncobj_manager_v1, wp_linux_drm_syncobj_surface_v1,
+        wp_linux_drm_syncobj_timeline_v1,
+    };
 
-pub fn register_linux_drm_syncobj(_display: &DisplayHandle) {
-    // TODO: Register global
+    pub struct SyncobjSurfaceData {
+        pub surface_id: u32,
+    }
+
+    pub struct SyncobjTimelineData {
+        pub fd: Option<i32>,
+    }
+
+    impl GlobalDispatch<wp_linux_drm_syncobj_manager_v1::WpLinuxDrmSyncobjManagerV1, ()>
+        for CompositorState
+    {
+        fn bind(
+            _state: &mut Self,
+            _handle: &DisplayHandle,
+            _client: &wayland_server::Client,
+            resource: wayland_server::New<
+                wp_linux_drm_syncobj_manager_v1::WpLinuxDrmSyncobjManagerV1,
+            >,
+            _global_data: &(),
+            data_init: &mut wayland_server::DataInit<'_, Self>,
+        ) {
+            let _mgr = data_init.init(resource, ());
+            tracing::info!(
+                target: "wwn.dmabuf",
+                op = "bind",
+                protocol = "wp_linux_drm_syncobj_manager_v1",
+                "linux-drm-syncobj manager bound"
+            );
+        }
+    }
+
+    impl Dispatch<wp_linux_drm_syncobj_manager_v1::WpLinuxDrmSyncobjManagerV1, ()>
+        for CompositorState
+    {
+        fn request(
+            state: &mut Self,
+            _client: &wayland_server::Client,
+            _resource: &wp_linux_drm_syncobj_manager_v1::WpLinuxDrmSyncobjManagerV1,
+            request: wp_linux_drm_syncobj_manager_v1::Request,
+            _data: &(),
+            _dhandle: &DisplayHandle,
+            data_init: &mut wayland_server::DataInit<'_, Self>,
+        ) {
+            match request {
+                wp_linux_drm_syncobj_manager_v1::Request::GetSurface { id, surface } => {
+                    let surface_id = surface.id().protocol_id();
+                    let sync = data_init.init(
+                        id,
+                        SyncobjSurfaceData { surface_id },
+                    );
+                    let sync_id = sync.id().protocol_id();
+                    state
+                        .ext
+                        .linux_drm_syncobj
+                        .surface_sync_states
+                        .insert(sync_id, surface_id);
+                    state
+                        .ext
+                        .linux_drm_syncobj
+                        .syncobj_surfaces
+                        .insert(sync_id, surface_id);
+                    tracing::debug!(
+                        target: "wwn.dmabuf",
+                        op = "create",
+                        protocol = "wp_linux_drm_syncobj_surface_v1",
+                        surface_id,
+                        "syncobj surface attached"
+                    );
+                }
+                wp_linux_drm_syncobj_manager_v1::Request::ImportTimeline { id, fd } => {
+                    use std::os::fd::IntoRawFd;
+                    let raw = fd.into_raw_fd();
+                    let timeline = data_init.init(
+                        id,
+                        SyncobjTimelineData {
+                            fd: Some(raw),
+                        },
+                    );
+                    let tid = timeline.id().protocol_id();
+                    state
+                        .ext
+                        .linux_drm_syncobj
+                        .syncobj_timelines
+                        .insert(tid, Some(raw));
+                    tracing::debug!(
+                        target: "wwn.dmabuf",
+                        op = "create",
+                        protocol = "wp_linux_drm_syncobj_timeline_v1",
+                        timeline_id = tid,
+                        "syncobj timeline imported"
+                    );
+                }
+                wp_linux_drm_syncobj_manager_v1::Request::Destroy => {}
+                _ => {}
+            }
+        }
+    }
+
+    impl Dispatch<wp_linux_drm_syncobj_surface_v1::WpLinuxDrmSyncobjSurfaceV1, SyncobjSurfaceData>
+        for CompositorState
+    {
+        fn request(
+            _state: &mut Self,
+            _client: &wayland_server::Client,
+            _resource: &wp_linux_drm_syncobj_surface_v1::WpLinuxDrmSyncobjSurfaceV1,
+            request: wp_linux_drm_syncobj_surface_v1::Request,
+            data: &SyncobjSurfaceData,
+            _dhandle: &DisplayHandle,
+            _data_init: &mut wayland_server::DataInit<'_, Self>,
+        ) {
+            match request {
+                wp_linux_drm_syncobj_surface_v1::Request::SetAcquirePoint {
+                    timeline: _,
+                    point_hi: _,
+                    point_lo: _,
+                }
+                | wp_linux_drm_syncobj_surface_v1::Request::SetReleasePoint {
+                    timeline: _,
+                    point_hi: _,
+                    point_lo: _,
+                } => {
+                    tracing::trace!(
+                        target: "wwn.dmabuf",
+                        op = "import",
+                        surface_id = data.surface_id,
+                        "syncobj acquire/release point set (acknowledged)"
+                    );
+                }
+                wp_linux_drm_syncobj_surface_v1::Request::Destroy => {}
+                _ => {}
+            }
+        }
+    }
+
+    impl Dispatch<wp_linux_drm_syncobj_timeline_v1::WpLinuxDrmSyncobjTimelineV1, SyncobjTimelineData>
+        for CompositorState
+    {
+        fn request(
+            _state: &mut Self,
+            _client: &wayland_server::Client,
+            _resource: &wp_linux_drm_syncobj_timeline_v1::WpLinuxDrmSyncobjTimelineV1,
+            request: wp_linux_drm_syncobj_timeline_v1::Request,
+            data: &SyncobjTimelineData,
+            _dhandle: &DisplayHandle,
+            _data_init: &mut wayland_server::DataInit<'_, Self>,
+        ) {
+            match request {
+                wp_linux_drm_syncobj_timeline_v1::Request::Destroy => {
+                    if let Some(fd) = data.fd {
+                        unsafe {
+                            libc::close(fd);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    pub fn register(display: &DisplayHandle) {
+        display.create_global::<
+            CompositorState,
+            wp_linux_drm_syncobj_manager_v1::WpLinuxDrmSyncobjManagerV1,
+            (),
+        >(1, ());
+        tracing::info!(
+            target: "wwn.dmabuf",
+            op = "bind",
+            protocol = "wp_linux_drm_syncobj_manager_v1",
+            "registered linux-drm-syncobj-v1"
+        );
+    }
 }
 
-
+pub fn register_linux_drm_syncobj(display: &DisplayHandle) {
+    #[cfg(feature = "desktop-protocols")]
+    {
+        proto::register(display);
+    }
+    #[cfg(not(feature = "desktop-protocols"))]
+    {
+        let _ = display;
+        tracing::debug!(
+            target: "wwn.dmabuf",
+            "linux-drm-syncobj skipped (desktop-protocols feature off)"
+        );
+    }
+}

--- a/src/core/wayland/ext/mod.rs
+++ b/src/core/wayland/ext/mod.rs
@@ -76,7 +76,7 @@ pub fn register(_state: &mut CompositorState, dh: &DisplayHandle) {
     text_input::register_text_input_manager(dh);
     text_input::register_text_input_manager_v1(dh);
     keyboard_shortcuts_inhibit::register_keyboard_shortcuts_inhibit_manager(dh);
-    linux_dmabuf::register_linux_dmabuf(dh);
+    let _ = linux_dmabuf::register_linux_dmabuf(dh);
     linux_explicit_sync::register_linux_explicit_sync(dh);
     input_timestamps::register_input_timestamps(dh);
 
@@ -137,6 +137,7 @@ pub fn register(_state: &mut CompositorState, dh: &DisplayHandle) {
             xwayland_keyboard_grab::register_xwayland_keyboard_grab(dh);
             xwayland_shell::register_xwayland_shell(dh);
             input_method::register_input_method_manager(dh);
+            linux_drm_syncobj::register_linux_drm_syncobj(dh);
         } else {
             crate::wlog!(
                 crate::util::logging::COMPOSITOR,

--- a/src/platform/android/android_jni.c
+++ b/src/platform/android/android_jni.c
@@ -175,6 +175,7 @@ enum {
   CWindowEventTypeUnmaximizeRequested = 11,
   CWindowEventTypeFullscreenRequested = 14,
   CWindowEventTypeUnfullscreenRequested = 15,
+  CWindowEventTypeSystemBell = 17,
 };
 typedef struct {
   uint64_t event_type;
@@ -593,6 +594,58 @@ static float g_display_density = 1.0f;
 
 // Compositor core pointer (set when Rust core is initialised)
 static void *g_core = NULL;
+static JavaVM *g_jvm = NULL;
+
+/** `xdg_system_bell_v1.ring` → ToneGenerator.TONE_PROP_BEEP (STREAM_NOTIFICATION). */
+static void android_ring_system_bell(void) {
+  if (!g_jvm) {
+    LOGI("SystemBell: no JavaVM");
+    return;
+  }
+  JNIEnv *env = NULL;
+  int need_detach = 0;
+  jint get_env = (*g_jvm)->GetEnv(g_jvm, (void **)&env, JNI_VERSION_1_6);
+  if (get_env == JNI_EDETACHED) {
+    if ((*g_jvm)->AttachCurrentThread(g_jvm, &env, NULL) != 0 || !env) {
+      LOGE("SystemBell: AttachCurrentThread failed");
+      return;
+    }
+    need_detach = 1;
+  } else if (get_env != JNI_OK || !env) {
+    LOGE("SystemBell: GetEnv failed");
+    return;
+  }
+
+  jclass cls =
+      (*env)->FindClass(env, "com/aspauldingcode/wawona/WawonaNative");
+  if (!cls) {
+    LOGE("SystemBell: FindClass WawonaNative failed");
+    if ((*env)->ExceptionCheck(env))
+      (*env)->ExceptionClear(env);
+    if (need_detach)
+      (*g_jvm)->DetachCurrentThread(g_jvm);
+    return;
+  }
+  jmethodID mid =
+      (*env)->GetStaticMethodID(env, cls, "ringSystemBell", "()V");
+  if (!mid) {
+    LOGE("SystemBell: GetStaticMethodID ringSystemBell failed");
+    if ((*env)->ExceptionCheck(env))
+      (*env)->ExceptionClear(env);
+    (*env)->DeleteLocalRef(env, cls);
+    if (need_detach)
+      (*g_jvm)->DetachCurrentThread(g_jvm);
+    return;
+  }
+  (*env)->CallStaticVoidMethod(env, cls, mid);
+  if ((*env)->ExceptionCheck(env)) {
+    LOGE("SystemBell: ringSystemBell threw");
+    (*env)->ExceptionClear(env);
+  }
+  (*env)->DeleteLocalRef(env, cls);
+  if (need_detach)
+    (*g_jvm)->DetachCurrentThread(g_jvm);
+}
 
 /* Modifier state for InjectModifiers (XKB modifier mask) */
 #define XKB_MOD_SHIFT (1 << 0)
@@ -1885,6 +1938,9 @@ static void choreographer_frame_cb(long frameTimeNanos, void *data) {
                                     /*fullscreen=*/0);
         break;
       }
+      case CWindowEventTypeSystemBell:
+        android_ring_system_bell();
+        break;
       default:
         break;
       }
@@ -1930,6 +1986,12 @@ static void choreographer_frame_cb(long frameTimeNanos, void *data) {
          * ILandIOSurface id. Lock CPU-mapped pixels and upload like SHM. */
         IOSurfaceRef surf = ILandIOSurfaceLookup(buf->iosurface_id);
         if (surf) {
+          __android_log_print(ANDROID_LOG_INFO, "WawonaDmabuf",
+                              "op=present os=android sink=ahb_surface "
+                              "backing_id=%u format=%u copy=cpu "
+                              "client=wayland (AHB lock→upload; zero-copy "
+                              "VkImage import is follow-on)",
+                              buf->iosurface_id, buf->format);
           ILandIOSurfaceLock(surf);
           void *base = ILandIOSurfaceGetBaseAddress(surf);
           uint32_t stride = (uint32_t)ILandIOSurfaceGetBytesPerRow(surf);
@@ -6118,27 +6180,167 @@ cleanup_strings:
 }
 
 static volatile int g_mobile_vm_running = 0;
+static pid_t g_mobile_vm_pid = -1;
+
+static int wwn_android_kvm_available(void) {
+  struct stat st;
+  return (stat("/dev/kvm", &st) == 0);
+}
+
+static int wwn_find_android_qemu(char *out, size_t out_sz) {
+  const char *candidates[] = {
+      "/data/data/com.aspauldingcode.wawona/lib/libqemu-system-aarch64.so",
+      NULL,
+  };
+  /* Prefer getenv for nativeLibraryDir passed as WAWONA_QEMU by Kotlin later. */
+  const char *envq = getenv("WAWONA_QEMU");
+  if (envq && envq[0] && access(envq, X_OK) == 0) {
+    snprintf(out, out_sz, "%s", envq);
+    return 1;
+  }
+  /* Kotlin writes filesDir/WAWONA_QEMU.path when nativeLibraryDir has qemu. */
+  {
+    const char *data = getenv("ANDROID_DATA");
+    char pathfile[512];
+    if (data && data[0]) {
+      snprintf(pathfile, sizeof(pathfile),
+               "%s/data/com.aspauldingcode.wawona/files/WAWONA_QEMU.path", data);
+    } else {
+      snprintf(pathfile, sizeof(pathfile),
+               "/data/data/com.aspauldingcode.wawona/files/WAWONA_QEMU.path");
+    }
+    FILE *f = fopen(pathfile, "r");
+    if (f) {
+      if (fgets(out, (int)out_sz, f)) {
+        size_t len = strlen(out);
+        while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r'))
+          out[--len] = '\0';
+        fclose(f);
+        if (len > 0 && (access(out, X_OK) == 0 || access(out, R_OK) == 0))
+          return 1;
+      } else {
+        fclose(f);
+      }
+    }
+  }
+  for (int i = 0; candidates[i]; i++) {
+    if (access(candidates[i], X_OK) == 0 || access(candidates[i], R_OK) == 0) {
+      snprintf(out, out_sz, "%s", candidates[i]);
+      return 1;
+    }
+  }
+  /* Bundled next to JNI libs: try common APK extract paths via /proc/self/exe dir. */
+  char self[512];
+  ssize_t n = readlink("/proc/self/exe", self, sizeof(self) - 1);
+  if (n > 0) {
+    self[n] = '\0';
+    char *slash = strrchr(self, '/');
+    if (slash) {
+      *slash = '\0';
+      snprintf(out, out_sz, "%s/libqemu-system-aarch64.so", self);
+      if (access(out, R_OK) == 0)
+        return 1;
+      snprintf(out, out_sz, "%s/qemu-system-aarch64", self);
+      if (access(out, X_OK) == 0)
+        return 1;
+    }
+  }
+  return 0;
+}
 
 JNIEXPORT jboolean JNICALL
 Java_com_aspauldingcode_wawona_WawonaNative_nativeLaunchMobileVm(
     JNIEnv *env, jclass clazz, jstring guest_dir, jint memory_mb) {
   (void)clazz;
-  (void)memory_mb;
   const char *dir = (*env)->GetStringUTFChars(env, guest_dir, NULL);
   if (!dir)
     return JNI_FALSE;
-  struct stat st;
+
   char rootfs[512];
+  char kernel[512];
   snprintf(rootfs, sizeof(rootfs), "%s/rootfs.img", dir);
+  struct stat st;
   int ok = (stat(rootfs, &st) == 0 && S_ISREG(st.st_mode));
+  kernel[0] = '\0';
   if (ok) {
-    g_mobile_vm_running = 1;
-    LOGI("mobile VM lane: guest at %s (embed QEMU engine to boot)", dir);
-  } else {
-    LOGE("mobile VM: missing %s", rootfs);
+    const char *names[] = {"Image", "zImage", "vmlinuz", "vmlinux", NULL};
+    for (int i = 0; names[i]; i++) {
+      snprintf(kernel, sizeof(kernel), "%s/%s", dir, names[i]);
+      if (stat(kernel, &st) == 0 && S_ISREG(st.st_mode))
+        break;
+      kernel[0] = '\0';
+    }
+    ok = kernel[0] != '\0';
   }
+
+  if (!ok) {
+    LOGE("mobile VM: incomplete guest under %s", dir);
+    (*env)->ReleaseStringUTFChars(env, guest_dir, dir);
+    return JNI_FALSE;
+  }
+
+  char qemu_bin[512];
+  if (!wwn_find_android_qemu(qemu_bin, sizeof(qemu_bin))) {
+    /* Guest present but engine not embedded yet: mark lane ready for UI,
+     * log clearly. Same posture as prior stub, but with HV probe. */
+    g_mobile_vm_running = 1;
+    LOGI("mobile VM: guest OK at %s; embed libqemu-system-aarch64.so to boot "
+         "(kvm=%d)",
+         dir, wwn_android_kvm_available());
+    (*env)->ReleaseStringUTFChars(env, guest_dir, dir);
+    return JNI_TRUE;
+  }
+
+  if (g_mobile_vm_pid > 0) {
+    kill(g_mobile_vm_pid, SIGTERM);
+    g_mobile_vm_pid = -1;
+  }
+
+  unsigned mem = memory_mb > 0 ? (unsigned)memory_mb : 768u;
+  char mem_arg[32];
+  snprintf(mem_arg, sizeof(mem_arg), "%u", mem);
+  char drive_arg[640];
+  snprintf(drive_arg, sizeof(drive_arg), "file=%s,if=virtio,format=raw", rootfs);
+
+  const char *accel = wwn_android_kvm_available() ? "kvm" : "tcg";
+  char machine_arg[64];
+  snprintf(machine_arg, sizeof(machine_arg), "virt,accel=%s", accel);
+
+  char *argv[] = {
+      qemu_bin,
+      "-machine",
+      machine_arg,
+      "-cpu",
+      "max",
+      "-m",
+      mem_arg,
+      "-kernel",
+      kernel,
+      "-drive",
+      drive_arg,
+      "-device",
+      "virtio-rng-pci",
+      "-nographic",
+      "-no-reboot",
+      NULL,
+  };
+
+  pid_t pid = fork();
+  if (pid == 0) {
+    execv(qemu_bin, argv);
+    _exit(127);
+  }
+  if (pid < 0) {
+    LOGE("mobile VM: fork failed");
+    (*env)->ReleaseStringUTFChars(env, guest_dir, dir);
+    return JNI_FALSE;
+  }
+
+  g_mobile_vm_pid = pid;
+  g_mobile_vm_running = 1;
+  LOGI("mobile VM: started pid=%d accel=%s qemu=%s", (int)pid, accel, qemu_bin);
   (*env)->ReleaseStringUTFChars(env, guest_dir, dir);
-  return ok ? JNI_TRUE : JNI_FALSE;
+  return JNI_TRUE;
 }
 
 JNIEXPORT void JNICALL
@@ -6146,6 +6348,10 @@ Java_com_aspauldingcode_wawona_WawonaNative_nativeStopMobileVm(JNIEnv *env,
                                                                jclass clazz) {
   (void)env;
   (void)clazz;
+  if (g_mobile_vm_pid > 0) {
+    kill(g_mobile_vm_pid, SIGTERM);
+    g_mobile_vm_pid = -1;
+  }
   g_mobile_vm_running = 0;
 }
 
@@ -6230,6 +6436,7 @@ Java_com_aspauldingcode_wawona_WawonaNative_nativeGithubBugReportUrl(
 }
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
+  g_jvm = vm;
   // Redirect stdout/stderr to logcat
   setvbuf(stdout, 0, _IOLBF, 0);
   setvbuf(stderr, 0, _IONBF, 0);

--- a/src/platform/ios/WWNIomfbPresenter.h
+++ b/src/platform/ios/WWNIomfbPresenter.h
@@ -1,0 +1,21 @@
+//
+// WWNIomfbPresenter.h - Mode B IOMobileFramebuffer present (TrollStore/Sileo)
+//
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Present an IOSurface id on the Mode B own-display panel.
+/// Returns true only on a real page-flip (`copy=zero`). Mode A builds always
+/// return false. Never call from App Store UI paths.
+BOOL WWNIomfbPresentIOSurface(uint32_t iosurfaceId, uint32_t width,
+                              uint32_t height, uint32_t format);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/platform/ios/WWNIomfbPresenter.m
+++ b/src/platform/ios/WWNIomfbPresenter.m
@@ -1,0 +1,47 @@
+//
+// WWNIomfbPresenter.m - iOS Mode B IOMobileFramebuffer present sink
+//
+// Linked only into WWN_MODE_B / Mode B schemes (TrollStore .tipa, Sileo .deb).
+// Store IPA must never compile this file. Same IOSurface objects as Mode A
+// Metal; this sink owns the panel instead of CAMetalLayer.
+//
+// Scaffolding: logs + no-op until entitlements + SPI are wired on device /
+// vphone jb.
+
+#import <Foundation/Foundation.h>
+#import <IOSurface/IOSurface.h>
+
+#if defined(WWN_MODE_B) && WWN_MODE_B
+
+BOOL WWNIomfbPresentIOSurface(uint32_t iosurfaceId, uint32_t width,
+                              uint32_t height, uint32_t format) {
+  (void)width;
+  (void)height;
+  (void)format;
+  IOSurfaceRef surf = IOSurfaceLookup(iosurfaceId);
+  if (!surf) {
+    NSLog(@"[WawonaDmabuf] op=present os=ios sink=iomfb backing_id=%u "
+          @"copy=cpu client=modeb lookup_failed",
+          iosurfaceId);
+    return NO;
+  }
+  CFRelease(surf);
+  NSLog(@"[WawonaDmabuf] op=present os=ios sink=iomfb backing_id=%u "
+        @"format=%u copy=zero client=modeb scaffolding",
+        iosurfaceId, format);
+  // TODO: IOMobileFramebufferGetMainDisplay → set layer surface → swap.
+  return NO;
+}
+
+#else
+
+BOOL WWNIomfbPresentIOSurface(uint32_t iosurfaceId, uint32_t width,
+                              uint32_t height, uint32_t format) {
+  (void)iosurfaceId;
+  (void)width;
+  (void)height;
+  (void)format;
+  return NO;
+}
+
+#endif

--- a/src/platform/macos/WWNCompositorBridge.m
+++ b/src/platform/macos/WWNCompositorBridge.m
@@ -17,8 +17,14 @@
 #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 #import "WWNWindow.h"
 #endif
-#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
+#if TARGET_OS_WATCH
+#import <WatchKit/WatchKit.h>
+#elif TARGET_OS_IPHONE || TARGET_OS_SIMULATOR || TARGET_OS_TV
 #import <UIKit/UIKit.h>
+#import <AudioToolbox/AudioToolbox.h>
+#elif defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#import <UIKit/UIKit.h>
+#import <AudioToolbox/AudioToolbox.h>
 #else
 #import <Cocoa/Cocoa.h>
 #endif
@@ -1788,6 +1794,11 @@ static void WWNCloseHostWindowSafely(NSWindow *window) {
   if (buffer->iosurface_id != 0) {
     IOSurfaceRef surf = IOSurfaceLookup(buffer->iosurface_id);
     if (surf) {
+      WWNLog("WawonaDmabuf",
+             @"op=present os=apple sink=apple_metal backing_id=%u format=%u "
+             @"copy=cpu client=wayland "
+             @"(IOSurface→CGImage host path; iland Metal presenter is copy=zero)",
+             buffer->iosurface_id, buffer->format);
       BOOL bottomUp = WWNBufferIsBottomUp(surf);
       // UIKit cannot assign IOSurface to CALayer.contents. AppKit can, but a
       // CALayer Y-scale under geometryFlipped looks like inverted X+Y, so both
@@ -3731,6 +3742,7 @@ typedef enum : uint32_t {
   CWindowEventTypeFullscreenRequested = 14,
   CWindowEventTypeUnfullscreenRequested = 15,
   CWindowEventTypeCloseRequested = 16,
+  CWindowEventTypeSystemBell = 17,
 } CWindowEventType;
 
 typedef struct CWindowEvent {
@@ -3831,6 +3843,9 @@ extern void WWNWindowInfoFree(CWindowInfo *info);
   case CWindowEventTypeHostLocked:
     [self handleWindowHostLocked:event];
     break;
+  case CWindowEventTypeSystemBell:
+    [self handleSystemBell:event];
+    break;
   }
 }
 
@@ -3894,6 +3909,21 @@ extern void WWNWindowInfoFree(CWindowInfo *info);
       postNotificationName:WWNClientMinimizeRequestedNotification
                     object:self
                   userInfo:info];
+#endif
+}
+
+/// `xdg_system_bell_v1.ring` → platform system alert / beep / haptic.
+- (void)handleSystemBell:(CWindowEvent *)event {
+  WWNLog("BRIDGE", @"SystemBell surface_id=%u", event->surface_id);
+#if TARGET_OS_WATCH
+  [[WKInterfaceDevice currentDevice] playHaptic:WKHapticTypeNotification];
+#elif TARGET_OS_IPHONE || TARGET_OS_SIMULATOR || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+  // iOS/tvOS/visionOS: no App Store-accessible user-preferred alert sound.
+  // Play a short system UI sound as the audible stand-in for BEL.
+  AudioServicesPlaySystemSound(1057);
+#else
+  // macOS: Sound settings → Sound Effects → Alert sound (`NSBeep`).
+  NSBeep();
 #endif
 }
 
@@ -4595,8 +4625,25 @@ static inline NSString *WWNSizeKindString(uint8_t kind) {
 #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
   id popup = [_popups objectForKey:@(event->window_id)];
   if (popup) {
+    uint64_t parentWindowId = 0;
+    if ([popup conformsToProtocol:@protocol(WWNPopupHost)]) {
+      WWNNativeView *parentView = ((id<WWNPopupHost>)popup).parentView;
+      NSWindow *parentWin = parentView.window;
+      if ([parentWin isKindOfClass:[WWNWindow class]]) {
+        parentWindowId = ((WWNWindow *)parentWin).wwnWindowId;
+      }
+    }
+    // Clear onDismiss before dismiss so we do not re-enter handlePopupDismissed
+    // and double-send popup_done (WindowDestroyed already means the client is
+    // gone / protocol teardown is in progress).
+    if ([popup conformsToProtocol:@protocol(WWNPopupHost)]) {
+      ((id<WWNPopupHost>)popup).onDismiss = nil;
+    }
     [self wwnRemovePopupHost:popup windowId:event->window_id];
     WWNLog("BRIDGE", @"Destroyed popup %llu", event->window_id);
+    if (parentWindowId != 0) {
+      [self injectKeyboardEnterForWindow:parentWindowId keys:@[]];
+    }
   }
 #endif
 }
@@ -4904,8 +4951,23 @@ static NSRect WWNScreenFrameForPopupInParentView(WWNView *parentView, CGFloat x,
 }
 
 - (void)handlePopupDismissed:(uint64_t)windowId {
-  WWNLog("BRIDGE", @"Popup dismissed locally: %llu", windowId);
   id popup = [_popups objectForKey:@(windowId)];
+  // Already torn down via WindowDestroyed -> wwnRemovePopupHost -> onDismiss.
+  // Do not send a second xdg_popup.popup_done (that races the client destroy).
+  if (!popup) {
+    return;
+  }
+  WWNLog("BRIDGE", @"Popup dismissed locally: %llu", windowId);
+
+  uint64_t parentWindowId = 0;
+  if ([popup conformsToProtocol:@protocol(WWNPopupHost)]) {
+    WWNNativeView *parentView = ((id<WWNPopupHost>)popup).parentView;
+    NSWindow *parentWin = parentView.window;
+    if ([parentWin isKindOfClass:[WWNWindow class]]) {
+      parentWindowId = ((WWNWindow *)parentWin).wwnWindowId;
+    }
+  }
+
   [self wwnRemovePopupHost:popup windowId:windowId];
   // Tell the client via xdg_popup.popup_done so it destroys the popup
   // instead of leaving a ghost grab.
@@ -4913,6 +4975,10 @@ static NSRect WWNScreenFrameForPopupInParentView(WWNView *parentView, CGFloat x,
     [self _dispatchToRust:^{
       WWNCoreNotifyPopupDismissed(self->_rustCore, windowId);
     }];
+  }
+  // GTK needs keyboard focus back on the parent before a second menu grab.
+  if (parentWindowId != 0) {
+    [self injectKeyboardEnterForWindow:parentWindowId keys:@[]];
   }
 }
 
@@ -6519,13 +6585,14 @@ static NSString *WWNIlandGpuClientDisplayTitle(NSString *clientId) {
 }
 
 - (void)handlePopupDismissed:(uint64_t)windowId {
-  WWNLog("BRIDGE", @"iOS popup dismissed: %llu", windowId);
   UIView *popupView = (UIView *)[_popups objectForKey:@(windowId)];
-  if (popupView) {
-    [popupView removeFromSuperview];
-    [_popups removeObjectForKey:@(windowId)];
-    [_windows removeObjectForKey:@(windowId)];
+  if (!popupView) {
+    return;
   }
+  WWNLog("BRIDGE", @"iOS popup dismissed: %llu", windowId);
+  [popupView removeFromSuperview];
+  [_popups removeObjectForKey:@(windowId)];
+  [_windows removeObjectForKey:@(windowId)];
   if (_rustCore) {
     [self _dispatchToRust:^{
       WWNCoreNotifyPopupDismissed(self->_rustCore, windowId);

--- a/src/tests/protocol_matrix.rs
+++ b/src/tests/protocol_matrix.rs
@@ -382,10 +382,111 @@ fn test_protocol_matrix_dmabuf_feedback_resolves() {
 
     assert!(
         !probe.unrenderable_formats_advertised,
-        "bare Format / non-IOSurface modifiers must not be advertised (unrenderable)"
+        "bare Format / non-native modifiers must not be advertised on Apple/Android"
     );
     assert!(
         probe.feedback_done,
         "dmabuf feedback must resolve with done (clients would stall otherwise)"
     );
+}
+
+#[test]
+fn test_protocol_matrix_dmabuf_native_modifier_only_on_apple() {
+    // On Apple hosts, LINEAR must not appear in modifier events (see
+    // docs/linux-dmabuf-zero-copy.md). Linux CI advertises LINEAR on purpose.
+    #[cfg(not(target_vendor = "apple"))]
+    {
+        return;
+    }
+    #[cfg(target_vendor = "apple")]
+    {
+        use wayland_client::protocol::wl_registry::WlRegistry;
+        use wayland_protocols::wp::linux_dmabuf::zv1::client::zwp_linux_dmabuf_v1;
+
+        const IOSURFACE_MODIFIER: u64 = 0x8000_0000_0000_0000;
+
+        #[derive(Default)]
+        struct ModProbe {
+            dmabuf: Option<(u32, u32)>,
+            saw_native: bool,
+            saw_linear: bool,
+        }
+
+        impl Dispatch<WlRegistry, ()> for ModProbe {
+            fn event(
+                state: &mut Self,
+                _proxy: &WlRegistry,
+                event: wl_registry::Event,
+                _data: &(),
+                _conn: &Connection,
+                _qh: &QueueHandle<Self>,
+            ) {
+                if let wl_registry::Event::Global {
+                    name,
+                    interface,
+                    version,
+                } = event
+                {
+                    if interface == "zwp_linux_dmabuf_v1" {
+                        state.dmabuf = Some((name, version));
+                    }
+                }
+            }
+        }
+
+        impl Dispatch<zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, ()> for ModProbe {
+            fn event(
+                state: &mut Self,
+                _proxy: &zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1,
+                event: zwp_linux_dmabuf_v1::Event,
+                _data: &(),
+                _conn: &Connection,
+                _qh: &QueueHandle<Self>,
+            ) {
+                match event {
+                    zwp_linux_dmabuf_v1::Event::Modifier {
+                        modifier_hi,
+                        modifier_lo,
+                        ..
+                    } => {
+                        let m = ((modifier_hi as u64) << 32) | (modifier_lo as u64);
+                        if (m & IOSURFACE_MODIFIER) != 0 {
+                            state.saw_native = true;
+                        }
+                        if m == 0 {
+                            state.saw_linear = true;
+                        }
+                    }
+                    zwp_linux_dmabuf_v1::Event::Format { .. } => {}
+                    _ => {}
+                }
+            }
+        }
+
+        impl Dispatch<wl_callback::WlCallback, ()> for ModProbe {
+            fn event(
+                _state: &mut Self,
+                _proxy: &wl_callback::WlCallback,
+                _event: wl_callback::Event,
+                _data: &(),
+                _conn: &Connection,
+                _qh: &QueueHandle<Self>,
+            ) {
+            }
+        }
+
+        let mut env = TestEnv::new();
+        let display = env.client.display();
+        let mut queue = env.client.new_event_queue::<ModProbe>();
+        let qh = queue.handle();
+        let registry = display.get_registry(&qh, ());
+        let mut probe = ModProbe::default();
+        env.wait_roundtrip(&mut queue, &mut probe);
+        let (name, version) = probe.dmabuf.expect("zwp_linux_dmabuf_v1");
+        let _dmabuf: zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1 =
+            registry.bind(name, version.min(4), &qh, ());
+        env.wait_roundtrip(&mut queue, &mut probe);
+        assert!(probe.saw_native, "Apple must advertise high-bit native modifier");
+        assert!(!probe.saw_linear, "Apple must not advertise LINEAR");
+    }
 }


### PR DESCRIPTION
## Summary
- Rewrite iOS Mode B channels: TrollStore = JIT + IOMobileFramebuffer Desktop; Sileo keeps Swinging Bridge / ElleKit / APT
- Compositor OS import switch for `zwp_linux_dmabuf_v1` (no LINEAR on Apple/Android; watchOS omits global); `wwn.dmabuf` logs; linux-drm-syncobj registration
- Ship scaffolding: `.tipa` / rootless+rootful `.deb` packaging + `release.yml` Mode B job (not Ship: beta)
- Nix `.#vphone-cli` jailbreak lab wrap; host SIP/AMFI OK; IPSW `vm create` blocked here by ~37G free disk

## Test plan
- [x] `cargo test test_protocol_matrix_dmabuf*`
- [x] `nix run .#vphone-cli -- --help`
- [ ] agent-device Mode A cells (sim/device) with `copy=zero` where Metal presenter applies
- [ ] Free ≥128G and `vm create wawona-jb -V jb` for Sileo/TrollStore proof
- [ ] Do **not** merge until proof matrix green for claimed slices

Sibling PRs: wawona.io, wwn-mcp, repo.wawona.io, wwn-waypipe (same branch name).